### PR TITLE
[FEAT] #69 - 추천 뷰 -> 생성 뷰 화면전환

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
            
-            let rootViewController = HomeViewController()
+            let rootViewController = ValueOnboardingViewController()
             let navigationController = UINavigationController(rootViewController: rootViewController)
             navigationController.isNavigationBarHidden = true
             window.rootViewController = navigationController

--- a/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
            
-            let rootViewController = ValueOnboardingViewController()
+            let rootViewController = HomeViewController()
             let navigationController = UINavigationController(rootViewController: rootViewController)
             navigationController.isNavigationBarHidden = true
             window.rootViewController = navigationController

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Extensions/UIViewController+.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Extensions/UIViewController+.swift
@@ -45,7 +45,7 @@ extension UIViewController {
     
     @objc
     func popViewController() {
-        self.navigationController?.popViewController(animated: true)
+        self.navigationController?.popToRootViewController(animated: true)
     }
     
     func hideKeyboardWhenTappedAround() {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -260,7 +260,7 @@ extension HomeViewController: UICollectionViewDelegate {
 extension HomeViewController {
     @objc
     func addBtnTapped(_sender: UIButton) {
-        Utils.push(navigationController, AddMissionViewController())
+        Utils.push(navigationController, RecommendViewController())
     }
     
     @objc

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
@@ -143,7 +143,7 @@ private extension RecommendViewController {
     @objc
     private func buttonTapped() {
         let nextViewController = AddMissionViewController()
-        navigationController?.pushViewController(nextViewController, animated: false)
+        navigationController?.pushViewController(nextViewController, animated: true)
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/Cells/RecommendActionFooterView.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/Cells/RecommendActionFooterView.swift
@@ -16,6 +16,10 @@ class RecommendActionFooterView: UICollectionReusableView {
     
     static let identifier: String = "RecommendActionFooterView"
     
+    // MARK: - Properties
+    
+    var clickedNextButton: (() -> Void)?
+    
     // MARK: - UI Components
     
     private let moreButton = UIButton()
@@ -43,6 +47,7 @@ extension RecommendActionFooterView {
             $0.setTitleColor(.gray4, for: .normal)
             $0.titleLabel?.font = .Pretendard(.medium, size: 14)
             $0.setUnderline()
+            $0.addTarget(self, action: #selector(moreButtonButtonTapped), for: .touchUpInside)
         }
     }
     
@@ -53,5 +58,13 @@ extension RecommendActionFooterView {
             $0.top.equalToSuperview().offset(34)
             $0.centerX.equalToSuperview()
         }
+    }
+}
+
+// MARK: - @objc function
+
+extension RecommendActionFooterView {
+    @objc func moreButtonButtonTapped(_ sender: UIButton) {
+        clickedNextButton?()
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
@@ -44,6 +44,16 @@ class RecommendActionViewController: UIViewController {
     }
 }
 
+// MARK: - @objc
+// 데이터 넘겨주는 코드 추가 필요
+extension RecommendActionViewController {
+    @objc
+    private func pushToAddMission() {
+        let nextViewController = AddMissionViewController()
+        navigationController?.pushViewController(nextViewController, animated: true)
+    }
+}
+
 // MARK: - Methods
 
 private extension RecommendActionViewController {
@@ -75,6 +85,7 @@ private extension RecommendActionViewController {
             $0.setTitleColor(.gray1, for: .normal)
             $0.titleLabel?.font = .Pretendard(.semiBold, size: 17.18) // 수정 필요
             $0.backgroundColor = .white
+            $0.addTarget(self, action: #selector(pushToAddMission), for: .touchUpInside)
         }
     }
     
@@ -201,6 +212,10 @@ extension RecommendActionViewController: UICollectionViewDataSource {
             return headerView
         } else {
             guard let footerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: RecommendActionFooterView.identifier, for: indexPath) as? RecommendActionFooterView else { return UICollectionReusableView() }
+            footerView.clickedNextButton = { [weak self] in
+                let nextViewContoller = AddMissionViewController()
+                self?.navigationController?.pushViewController(nextViewContoller, animated: true)
+            }
             return footerView
         }
     }


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
 - 추천 뷰에서 아무것도 선택하지 않고 생성 뷰로 이동
 - 추천 뷰에서 실천행동까지 선택 후 데이터 전달 없이 생성 뷰로 이동
 - 추천 뷰에서 실천행동까지 선택 후 데이터 전달과 함께 생성 뷰로 이동

## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 추천 뷰에서 실천행동까지 선택 후 실제 데이터 값을 생성 뷰로 넘겨주는 부분은 아직 구현하지 않았습니다.
- 생성뷰에서 X버튼 클릭 시 항상 HomeViewController로 이동


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|     추천 뷰 -> 생성 뷰       |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/3e4dd423-eeda-44a4-9013-3142b9014e16" width ="250">|
|     추천 뷰 -> 실천행동 선택 -> 생성 뷰       |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/d640d53d-8bc9-43ff-8366-483415a440af" width ="250">|
|     추천 뷰 -> 실천행동 미선택 -> 생성 뷰       |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/4011cd7d-c4f0-4ba8-81d0-b21a00229d36" width ="250">|

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #69
