### PR TITLE
[Fix] #74 - 탈퇴 모달 flow 변경

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
            
-            let rootViewController = TabBarController()
+            let rootViewController = ValueOnboardingViewController()
             let navigationController = UINavigationController(rootViewController: rootViewController)
             navigationController.isNavigationBarHidden = true
             window.rootViewController = navigationController

--- a/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
            
-            let rootViewController = ValueOnboardingViewController()
+            let rootViewController = TabBarController()
             let navigationController = UINavigationController(rootViewController: rootViewController)
             navigationController.isNavigationBarHidden = true
             window.rootViewController = navigationController

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Modal/NottodoModalViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Modal/NottodoModalViewController.swift
@@ -17,7 +17,7 @@ final class NottodoModalViewController: UIViewController {
     
     // MARK: - Properties
     
-    private var viewType: ViewType? = .quit {
+    private var viewType: ViewType? = .quitSurvey {
         didSet {
             setUI()
             setLayout()
@@ -83,10 +83,20 @@ extension NottodoModalViewController {
 extension NottodoModalViewController: ModalDelegate {
     func modalAction() {
         switch viewType {
-        case .quit:
-            viewType = .quitSurvey
-        default:
+        case .quitSurvey:
             Utils.myInfoUrl(vc: self, url: MyInfoURL.googleForm.url)
+            viewType = .quit
+            withdrawView.isHidden = true
+        case .quit:
+            let authViewController = AuthViewController()
+            if let window = view.window?.windowScene?.keyWindow {
+                let TabBarController = TabBarController()
+                let navigationController = UINavigationController(rootViewController: authViewController)
+                navigationController.isNavigationBarHidden = true
+                window.rootViewController = navigationController
+            }
+        default:
+            viewType = .quit
         }
     }
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
@@ -56,7 +56,7 @@ private extension RecommendViewController {
         
         dismissButton.do {
             $0.setBackgroundImage(.delete, for: .normal)
-            $0.addTarget(self, action: #selector(self.dismissViewController), for: .touchUpInside)
+            $0.addTarget(self, action: #selector(self.popViewController), for: .touchUpInside)
         }
         
         navigationTitle.do {


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 탈퇴 모달 flow를 화면설계서에 맞게 수정하였습니다.

## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 추천 뷰가 사라지는 방식을 dismiss 방식에서 pop 방식으로 수정하였습니다.
- 탈퇴 버튼 후 navigationController의 첫번째 뷰가 로그인 뷰가 되도록 작업하였습니다.


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   탈퇴 flow     |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/41a7d9a6-aeb5-4163-81d5-0a34b37461a4" width ="250">|
|   탈퇴 후 navigationController     |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/aa70ca2d-7424-4292-be5a-e95140e600ab" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #74
