### PR TITLE
[Fix] #80 - 소셜 로그인 코드 수정

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
@@ -23,7 +23,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         KakaoSDK.initSDK(appKey: "f06c671df540ff4a8f8275f453368748")
         
-        if KeychainUtil.getSocialToken() != "" {
+        // 낫투두 서버로부터 받은 토큰이 유효할 경우
+        // 토큰이 유효한지 확인할 방법이 없으므로 UserDefaults에 값이 있는 경우로 대체
+        if KeychainUtil.getAccessToken() != "" {
             self.skipAuthView()
             print("토큰유효!!!!!")
         } else {

--- a/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
@@ -20,66 +20,42 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-
+        
         KakaoSDK.initSDK(appKey: "f06c671df540ff4a8f8275f453368748")
         
-//        if UserDefaults.standard.string(forKey: "KakaoAccessToken") != nil {
-//            UserApi.shared.accessTokenInfo { (_, error) in
-//                if let _ = error {
-//                    // 카카오 로그인 정보가 유효하지 않은 경우
-//                    self.checkAppleLoginStatus()
-//                } else {
-//                    // 카카오 로그인 정보가 유효한 경우
-//                    self.skipAuthView()
-//                }
-//            }
-//        } else {
-//            // 카카오 로그인 정보가 없는 경우
-//            checkAppleLoginStatus()
-//        }
-
+        if KeychainUtil.getSocialToken() != "" {
+            self.skipAuthView()
+            print("토큰유효!!!!!")
+        } else {
+            // self.showAuthView()
+            // 토큰이 유효하지 않을 경우 일단은 온보딩->로그인->홈 이렇게 가도록
+            print("토큰없넹!!!!!")
+        }
         return true
     }
-
-//    func checkAppleLoginStatus() {
-//        if UserDefaults.standard.bool(forKey: "isAppleLogin") {
-//            let appleIDProvider = ASAuthorizationAppleIDProvider()
-//            appleIDProvider.getCredentialState(forUserID: UserDefaults.standard.string(forKey: "AppleAccessToken") ?? "") { credentialState, _ in
-//                switch credentialState {
-//                case .authorized:
-//                    // 애플 로그인 정보가 유효한 경우
-//                    self.skipAuthView()
-//                case .revoked, .notFound:
-//                    // 애플 로그인 정보가 유효하지 않은 경우
-//                    self.showAuthView()
-//                default:
-//                    break
-//                }
-//            }
-//        } else {
-//            // 애플 로그인 정보가 없는 경우
-//            showAuthView()
-//        }
-//    }
-//
-//    func showAuthView() {
-//        DispatchQueue.main.async {
-//            let authViewController = AuthViewController()
-//            self.window = UIWindow(frame: UIScreen.main.bounds)
-//            self.window?.rootViewController = authViewController
-//            self.window?.makeKeyAndVisible()
-//        }
-//    }
-//
-//    func skipAuthView() {
-//        // 홈 화면으로 바로 이동
-//        DispatchQueue.main.async {
-//            let homeViewController = HomeViewController()
-//            self.window = UIWindow(frame: UIScreen.main.bounds)
-//            self.window?.rootViewController = homeViewController
-//            self.window?.makeKeyAndVisible()
-//        }
-//    }
+    
+    func showAuthView() {
+        DispatchQueue.main.async {
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let window = windowScene.windows.first {
+                let authViewController = AuthViewController()
+                window.rootViewController = authViewController
+                window.makeKeyAndVisible()
+            }
+        }
+    }
+    
+    func skipAuthView() {
+        // 홈 화면으로 바로 이동
+        DispatchQueue.main.async {
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let window = windowScene.windows.first {
+                let tabBarController = TabBarController()
+                window.rootViewController = tabBarController
+                window.makeKeyAndVisible()
+            }
+        }
+    }
 }
 
 // MARK: UISceneSession Lifecycle

--- a/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             print("토큰유효!!!!!")
         } else {
             // self.showAuthView()
-            // 토큰이 유효하지 않을 경우 일단은 온보딩->로그인->홈 이렇게 가도록
+            // 토큰이 유효하지 않을 경우 일단은 온보딩->로그인->홈 이렇게만 가도록
             print("토큰없넹!!!!!")
         }
         return true

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Literals/Strings.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Literals/Strings.swift
@@ -22,6 +22,7 @@ struct I18N {
     static let moreAuth = "이용약관 및 개인정보 처리방침"
     static let condition = "이용약관"
     static let personalInfo = "개인정보 처리방침"
+    static let moreLink = "https://teamnottodo.notion.site/0c3c7c02857b46e1b16307ce7a8f6ca9"
     
     /// Recommend
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
@@ -183,7 +183,6 @@ extension AuthViewController {
                 print("kakaoLoginWithApp() success.")
                 
                 if let accessToken = oauthToken?.accessToken {
-                  //  UserDefaults.standard.set(accessToken, forKey: "KakaoAccessToken")
                     KeychainUtil.setSocialToken(accessToken)
                     self.getUserInfo()
                 }
@@ -199,7 +198,6 @@ extension AuthViewController {
                 print("kakaoLoginWithAccount() success.")
                 
                 if let accessToken = oauthToken?.accessToken {
-                 //   UserDefaults.standard.set(accessToken, forKey: "KakaoAccessToken")
                     KeychainUtil.setSocialToken(accessToken)
                     
                     self.getUserInfo()
@@ -219,16 +217,6 @@ extension AuthViewController {
                 KeychainUtil.setString(name, forKey: DefaultKeys.name)
                 KeychainUtil.setString(email, forKey: DefaultKeys.email)
                 KeychainUtil.setBool(false, forKey: DefaultKeys.isAppleLogin)
-                
-//                UserDefaults.standard.set(name, forKey: "KakaoName")
-//                UserDefaults.standard.set(email, forKey: "KakaoEmail")
-//                UserDefaults.standard.set(false, forKey: "isAppleLogin")
-                
-//                self.requestAuthAPI(social: "KAKAO",
-//                               socialToken: UserDefaults.standard.string(forKey: "KakaoAccessToken") ?? "",
-//                               fcmToken: "1", name: UserDefaults.standard.string(forKey: "KakaoName") ?? "익명의 도전자",
-//                                    email: UserDefaults.standard.string(forKey: "KakaoEmail") ?? "연동된 이메일 정보가 없습니다")
-               // self.presentToHomeViewController()
                 
                 self.requestAuthAPI(social: LoginType.Kakao.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken, name: KeychainUtil.getUsername(), email: KeychainUtil.getEmail())
             }
@@ -259,13 +247,11 @@ extension AuthViewController: ASAuthorizationControllerDelegate, ASAuthorization
             
             if let accessToken = appleIDCredential.identityToken {
                 if let accessTokenString = String(data: accessToken, encoding: .utf8) {
-                    // UserDefaults.standard.setValue(accessTokenString, forKey: "AppleAccessToken")
                     KeychainUtil.setSocialToken(accessTokenString)
                 }
             }
             
             if let email = appleIDCredential.email {
-              //  UserDefaults.standard.setValue(email, forKey: "AppleUserEmail")
                 KeychainUtil.setString(email, forKey: DefaultKeys.email)
             }
             
@@ -273,18 +259,11 @@ extension AuthViewController: ASAuthorizationControllerDelegate, ASAuthorization
             let lastName = appleIDCredential.fullName?.familyName
             if let firstName = firstName, let lastName = lastName {
                 let fullName = "\(lastName)\(firstName)"
-               // UserDefaults.standard.setValue(fullName, forKey: "AppleUserName")
                 KeychainUtil.setString(fullName, forKey: DefaultKeys.name)
-
             }
             
-           // UserDefaults.standard.set(true, forKey: "isAppleLogin")
             KeychainUtil.setBool(true, forKey: DefaultKeys.isAppleLogin)
-        
-//            self.requestAuthAPI(social: "APPLE",
-//                           socialToken: UserDefaults.standard.string(forKey: "AppleAccessToken") ?? "",
-//                                fcmToken: "1", name: UserDefaults.standard.string(forKey: "AppleUserName") ?? "익명의 도전자", email: UserDefaults.standard.string(forKey: "AppleUserEmail") ?? "연동된 이메일 정보가 없습니다")
-//            self.presentToHomeViewController()
+
             self.requestAuthAPI(social: LoginType.Apple.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken, name: KeychainUtil.getUsername(), email: KeychainUtil.getEmail())
         default:
             break

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
@@ -6,14 +6,14 @@
 //
 
 import UIKit
+
+import AuthenticationServices
+import SafariServices
 import SnapKit
 import Then
-
 import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
-
-import AuthenticationServices
 
 class AuthViewController: UIViewController {
     
@@ -28,7 +28,7 @@ class AuthViewController: UIViewController {
     private var kakaoLoginButton = UIButton()
     private var appleLoginButton = UIButton()
     
-    private var moreLabel = UILabel()
+    private var moreButton = UIButton()
     private var conditionButton = UIButton()
     private var personalInfoButton = UIButton()
     
@@ -63,10 +63,10 @@ extension AuthViewController {
         kakaoLoginButton.addTarget(self, action: #selector(kakaoLoginButtonClicked), for: .touchUpInside)
         appleLoginButton.addTarget(self, action: #selector(appleLoginButtonClicked), for: .touchUpInside)
         
-        moreLabel.do {
-            $0.text = I18N.moreAuth
-            $0.textColor = .gray4
-            $0.font = .Pretendard(.regular, size: 12)
+        moreButton.do {
+            $0.setTitle(I18N.moreAuth, for: .normal)
+            $0.setTitleColor(.gray4, for: .normal)
+            $0.titleLabel?.font = .Pretendard(.regular, size: 12)
         }
         
         conditionButton.do {
@@ -74,6 +74,7 @@ extension AuthViewController {
             $0.setTitleColor(.gray4, for: .normal)
             $0.titleLabel?.font = .Pretendard(.regular, size: 12)
             $0.setUnderline()
+            $0.addTarget(self, action: #selector(moreButtonTapped), for: .touchUpInside)
         }
         
         personalInfoButton.do {
@@ -81,13 +82,14 @@ extension AuthViewController {
             $0.setTitleColor(.gray4, for: .normal)
             $0.titleLabel?.font = .Pretendard(.regular, size: 12)
             $0.setUnderline()
+            $0.addTarget(self, action: #selector(moreButtonTapped), for: .touchUpInside)
         }
     }
     
     private func setLayout() {
         
-        view.addSubviews(loginMainLabel, loginSubLabel, kakaoLoginImageView, kakaoLoginButtonView, appleLoginButtonView, kakaoLoginButton, appleLoginButton, moreLabel)
-        moreLabel.addSubviews(conditionButton, personalInfoButton)
+        view.addSubviews(loginMainLabel, loginSubLabel, kakaoLoginImageView, kakaoLoginButtonView, appleLoginButtonView, kakaoLoginButton, appleLoginButton, moreButton)
+        moreButton.addSubviews(conditionButton, personalInfoButton)
         
         loginMainLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(155)
@@ -99,14 +101,14 @@ extension AuthViewController {
             $0.leading.equalTo(loginMainLabel.snp.leading)
         }
         
-        moreLabel.snp.makeConstraints {
+        moreButton.snp.makeConstraints {
             $0.bottom.equalToSuperview().offset(-65)
             $0.centerX.equalToSuperview()
         }
         
         appleLoginButtonView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(moreLabel.snp.top).offset(-14)
+            $0.bottom.equalTo(moreButton.snp.top).offset(-14)
         }
         
         kakaoLoginButtonView.snp.makeConstraints {
@@ -151,6 +153,10 @@ extension AuthViewController {
     }
     
     // MARK: - @objc Methods
+    
+    @objc func moreButtonTapped() {
+        Utils.myInfoUrl(vc: self, url: MyInfoURL.service.url)
+    }
     
     @objc func kakaoLoginButtonClicked() {
         if UserApi.isKakaoTalkLoginAvailable() {


### PR DESCRIPTION
## 🫧 작업한 내용

소셜 로그인 코드 수정

## 🔫 PR Point

로그인 성공 시 낫투두 서버로부터 토큰을 받아 UserDefaults에 저장합니다.
자동로그인을 위해 AppDelegate에서 앱 실행 시 해당 토큰이 유효한지 확인합니다.

* 유효할 경우: 홈 화면으로 이동
토큰이 유효한지 서버를 통해 확인할 방법이 없으므로, UserDefaults에 값이 있는 경우 토큰이 유효하다고 판단

* 유효하지 않을 경우: 일단은 온보딩→로그인→홈 이렇게 이동하도록 설정
현재 토큰의 만료기한이 30년이므로 한번도 로그인을 시도하지 않은 사람만 해당
만약 낫투두가 30년 후에도 존재한다면... 토큰이 만료되어 로그아웃 된 사용자가 온보딩 뷰를 또 봐야하는 문제 발생

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #80 
