### PR TITLE
[Design] #91 - 낫투두 생성 뷰 토글 닫혔을 때 UI 구현

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Literals/Strings.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Literals/Strings.swift
@@ -92,6 +92,8 @@ struct I18N {
                           실천방법과 목표를 입력하면
                           낫투두 성공 확률이 더욱 올라가요!
                           """
+    static let enterMessage = "입력하세요..."
+    static let option = "*선택"
     
     /// MyInfo
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
@@ -28,6 +28,8 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private let exampleNottodo = UILabel()
     private let exampleActionOne = UILabel()
     private let exampleActionTwo = UILabel()
+    private let stackView = UIStackView()
+    private let exampleStackView = UIStackView()
     
     // MARK: - Life Cycle
     override init(frame: CGRect) {
@@ -44,7 +46,6 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     func setFoldState(_ state: FoldState) {
         fold = state
         missionCellHeight?(state == .folded ? 54 : 289)
-        updateLayout()
         updateUI()
         setKeyboardReturnType()
         contentView.layoutIfNeeded()
@@ -57,6 +58,12 @@ extension ActionCollectionViewCell {
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
+        stackView.axis = .vertical
+        
+        exampleStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 8
+        }
         
         exampleLabel.do {
             $0.text = I18N.example
@@ -80,57 +87,46 @@ extension ActionCollectionViewCell {
     }
     
     private func setLayout() {
-        contentView.addSubviews(titleLabel, subTitleLabel, addMissionTextField, exampleLabel,
-                    exampleNottodo, exampleActionOne, exampleActionTwo)
-        updateLayout()
-        updateUI()
-    }
-    
-    private func updateLayout() {
+        exampleStackView.addArrangedSubviews(exampleLabel, exampleNottodo)
+        stackView.addArrangedSubviews(titleLabel, subTitleLabel, addMissionTextField, exampleStackView, exampleActionOne, exampleActionTwo)
+        contentView.addSubviews(stackView)
         
-        titleLabel.snp.makeConstraints {
+        stackView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(16)
-            $0.leading.equalToSuperview().inset(21)
+            $0.leading.trailing.equalToSuperview().inset(22)
+        }
+        
+        stackView.do {
+            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(25, after: subTitleLabel)
+            $0.setCustomSpacing(12, after: addMissionTextField)
+            $0.setCustomSpacing(8, after: exampleStackView)
+            $0.setCustomSpacing(6, after: exampleActionOne)
+            $0.setCustomSpacing(31, after: exampleActionTwo)
         }
         
         subTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
-            $0.leading.equalToSuperview().inset(23)
+            $0.height.equalTo(60)
         }
         
-//        let textFieldHeight: CGFloat = fold == .folded ? 0 : 48
         addMissionTextField.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(25)
-            $0.directionalHorizontalEdges.equalToSuperview().inset(23)
-            $0.height.equalTo(48)
+            $0.height.equalTo(49)
         }
         
-        exampleLabel.snp.makeConstraints {
-            $0.top.equalTo(addMissionTextField.snp.bottom).offset(12)
-            $0.leading.equalToSuperview().inset(23)
-        }
-        
-        exampleNottodo.snp.makeConstraints {
-            $0.centerY.equalTo(exampleLabel)
-            $0.leading.equalTo(exampleLabel.snp.trailing).offset(8)
-        }
-        
-        exampleActionOne.snp.makeConstraints {
-            $0.top.equalTo(exampleNottodo.snp.bottom).offset(8)
-            $0.leading.equalTo(exampleNottodo.snp.leading)
-        }
-        
-        exampleActionTwo.snp.makeConstraints {
-            $0.top.equalTo(exampleActionOne.snp.bottom).offset(6)
-            $0.leading.equalTo(exampleNottodo.snp.leading)
+        [exampleActionOne, exampleActionTwo, exampleNottodo].forEach {
+            $0.snp.makeConstraints {
+                $0.leading.equalToSuperview().inset(37)
+            }
         }
     }
     
     private func updateUI() {
         let isHidden: Bool = (fold == .folded)
         
-        [titleLabel, subTitleLabel, addMissionTextField, exampleLabel, exampleNottodo,
+        [subTitleLabel, addMissionTextField, exampleLabel, exampleNottodo,
          exampleActionOne, exampleActionTwo].forEach { $0.isHidden = isHidden }
+        
+        titleLabel.setTitleColor(isHidden)
     }
     
     private func setKeyboardReturnType() {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
@@ -31,6 +31,11 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private let stackView = UIStackView()
     private let exampleStackView = UIStackView()
     
+    private let foldStackView = UIStackView()
+    private let enterMessage = UILabel()
+    private let paddingView = UIView()
+    private let optionLabel = UILabel()
+    
     // MARK: - Life Cycle
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -59,6 +64,11 @@ extension ActionCollectionViewCell {
         layer.cornerRadius = 12
         layer.borderWidth = 1
         stackView.axis = .vertical
+        foldStackView.do {
+            $0.axis = .horizontal
+            $0.distribution = .fill
+            $0.spacing = 9
+        }
         
         exampleStackView.do {
             $0.axis = .horizontal
@@ -84,11 +94,24 @@ extension ActionCollectionViewCell {
         
         exampleActionOne.text = I18N.exampleGoal
         exampleActionTwo.text = I18N.exampleAction
+        
+        enterMessage.do {
+            $0.text = I18N.enterMessage
+            $0.textColor = .gray3
+            $0.font = .Pretendard(.regular, size: 15)
+        }
+        
+        optionLabel.do {
+            $0.text = I18N.option
+            $0.textColor = .green1
+            $0.font = .Pretendard(.regular, size: 15)
+        }
     }
     
     private func setLayout() {
+        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView, optionLabel)
         exampleStackView.addArrangedSubviews(exampleLabel, exampleNottodo)
-        stackView.addArrangedSubviews(titleLabel, subTitleLabel, addMissionTextField, exampleStackView, exampleActionOne, exampleActionTwo)
+        stackView.addArrangedSubviews(foldStackView, subTitleLabel, addMissionTextField, exampleStackView, exampleActionOne, exampleActionTwo)
         contentView.addSubviews(stackView)
         
         stackView.snp.makeConstraints {
@@ -97,7 +120,7 @@ extension ActionCollectionViewCell {
         }
         
         stackView.do {
-            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(10, after: foldStackView)
             $0.setCustomSpacing(25, after: subTitleLabel)
             $0.setCustomSpacing(12, after: addMissionTextField)
             $0.setCustomSpacing(8, after: exampleStackView)
@@ -125,7 +148,7 @@ extension ActionCollectionViewCell {
         
         [subTitleLabel, addMissionTextField, exampleLabel, exampleNottodo,
          exampleActionOne, exampleActionTwo].forEach { $0.isHidden = isHidden }
-        
+        [enterMessage, optionLabel].forEach { $0.isHidden = !isHidden }
         titleLabel.setTitleColor(isHidden)
     }
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -26,6 +26,7 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     // 캘린더뷰가 들어갈 공간
     let calendarView = CalendarView(calendarScope: .month, scrollDirection: .horizontal)
     private let warningLabel = UILabel()
+    private let stackView = UIStackView()
     
     // MARK: - Life Cycle
     override init(frame: CGRect) {
@@ -42,7 +43,6 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     func setFoldState(_ state: FoldState) {
         fold = state
         missionCellHeight?(state == .folded ? 54 : 470)
-        updateLayout()
         updateUI()
         contentView.layoutIfNeeded()
     }
@@ -55,6 +55,7 @@ private extension DateCollectionViewCell {
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
+        stackView.axis = .vertical
         
         warningLabel.do {
             $0.text = I18N.dateWarning
@@ -70,9 +71,38 @@ private extension DateCollectionViewCell {
     }
     
     private func setLayout() {
-        contentView.addSubviews(titleLabel, subTitleLabel, calendarView, warningLabel)
-        updateLayout()
-        updateUI()
+        stackView.addArrangedSubviews(titleLabel, subTitleLabel, calendarView, warningLabel)
+        contentView.addSubviews(stackView)
+        
+        stackView.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        stackView.do {
+            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(0, after: subTitleLabel)
+            $0.setCustomSpacing(13, after: calendarView)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(6)
+        }
+        
+        subTitleLabel.snp.makeConstraints {
+            $0.height.equalTo(30)
+            $0.leading.equalTo(titleLabel.snp.leading)
+        }
+        
+        calendarView.snp.makeConstraints {
+            $0.height.equalTo((UIScreen.main.bounds.size.width-60)*1.05)
+            $0.directionalHorizontalEdges.equalToSuperview()
+        }
+        
+        calendarView.calendar.snp.updateConstraints {
+            $0.bottom.equalToSuperview()
+            $0.directionalHorizontalEdges.equalToSuperview().inset(13)
+        }
     }
     
     private func updateLayout() {
@@ -93,21 +123,18 @@ private extension DateCollectionViewCell {
         
         calendarView.snp.makeConstraints {
             $0.top.equalTo(subTitleLabel.snp.bottom)
-            $0.directionalHorizontalEdges.equalToSuperview()
+
             $0.height.equalTo((UIScreen.main.bounds.size.width-60)*1.05)
-        }
-        
-        calendarView.calendar.snp.updateConstraints {
-            $0.bottom.equalToSuperview()
-            $0.directionalHorizontalEdges.equalToSuperview().inset(13)
         }
     }
 
     private func updateUI() {
         let isHidden: Bool = ( fold == .folded )
-        [titleLabel, subTitleLabel, calendarView, warningLabel].forEach {
+        [subTitleLabel, calendarView, warningLabel].forEach {
             $0.isHidden = isHidden
         }
+        
+        titleLabel.setTitleColor(isHidden)
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
@@ -30,8 +30,15 @@ final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private let stackView = UIStackView()
     private let nottodoStackView = UIStackView()
     private let goalStackView = UIStackView()
+    private let nottodoPaddingView = UIView()
+    private let goalPaddingView = UIView()
     private let nottodoTag = PaddingLabel(padding: UIEdgeInsets(top: 3, left: 13, bottom: 3, right: 13))
     private let goalTag = PaddingLabel(padding: UIEdgeInsets(top: 3, left: 13, bottom: 3, right: 13))
+    
+    private let foldStackView = UIStackView()
+    private let enterMessage = UILabel()
+    private let paddingView = UIView()
+    private let optionLabel = UILabel()
     
     // MARK: - Life Cycle
     override init(frame: CGRect) {
@@ -63,6 +70,13 @@ private extension GoalCollectionViewCell {
         [nottodoStackView, goalStackView].forEach {
             $0.axis = .horizontal
             $0.spacing = 5
+            $0.distribution = .fill
+        }
+        
+        foldStackView.do {
+            $0.axis = .horizontal
+            $0.distribution = .fill
+            $0.spacing = 39
         }
         
         exampleLabel.do {
@@ -93,12 +107,25 @@ private extension GoalCollectionViewCell {
             $0.textColor = .gray4
             $0.font = .Pretendard(.medium, size: 13)
         }
+        
+        enterMessage.do {
+            $0.text = I18N.enterMessage
+            $0.textColor = .gray3
+            $0.font = .Pretendard(.regular, size: 15)
+        }
+        
+        optionLabel.do {
+            $0.text = I18N.option
+            $0.textColor = .green1
+            $0.font = .Pretendard(.regular, size: 15)
+        }
     }
     
     func setLayout() {
-        stackView.addArrangedSubviews(titleLabel, subTitleLabel, addMissionTextField, exampleLabel, nottodoStackView, goalStackView)
-        nottodoStackView.addArrangedSubviews(nottodoTag, exampleNottodoLabel)
-        goalStackView.addArrangedSubviews(goalTag, exampleGoalLabel)
+        stackView.addArrangedSubviews(foldStackView, subTitleLabel, addMissionTextField, exampleLabel, nottodoStackView, goalStackView)
+        nottodoStackView.addArrangedSubviews(nottodoTag, exampleNottodoLabel, nottodoPaddingView)
+        goalStackView.addArrangedSubviews(goalTag, exampleGoalLabel, goalPaddingView)
+        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView, optionLabel)
         contentView.addSubviews(stackView)
         
         stackView.snp.makeConstraints {
@@ -111,19 +138,11 @@ private extension GoalCollectionViewCell {
         }
         
         stackView.do {
-            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(10, after: foldStackView)
             $0.setCustomSpacing(25, after: subTitleLabel)
             $0.setCustomSpacing(13, after: addMissionTextField)
             $0.setCustomSpacing(8, after: exampleLabel)
             $0.setCustomSpacing(5, after: nottodoStackView)
-        }
-        
-        nottodoTag.snp.makeConstraints {
-            $0.width.equalTo(58)
-        }
-        
-        goalTag.snp.makeConstraints {
-            $0.width.equalTo(47)
         }
         
         subTitleLabel.snp.makeConstraints {
@@ -139,7 +158,7 @@ private extension GoalCollectionViewCell {
         let isHidden: Bool = (fold == .folded)
         
         [subTitleLabel, addMissionTextField, exampleLabel, nottodoStackView, goalStackView].forEach { $0.isHidden = isHidden }
-        
+        [enterMessage, optionLabel].forEach { $0.isHidden = !isHidden }
         titleLabel.setTitleColor(isHidden)
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
@@ -27,6 +27,9 @@ final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private let exampleLabel = UILabel()
     private let exampleNottodoLabel = UILabel()
     private let exampleGoalLabel = UILabel()
+    private let stackView = UIStackView()
+    private let nottodoStackView = UIStackView()
+    private let goalStackView = UIStackView()
     private let nottodoTag = PaddingLabel(padding: UIEdgeInsets(top: 3, left: 13, bottom: 3, right: 13))
     private let goalTag = PaddingLabel(padding: UIEdgeInsets(top: 3, left: 13, bottom: 3, right: 13))
     
@@ -45,7 +48,6 @@ final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     func setFoldState(_ state: FoldState) {
         fold = state
         missionCellHeight?(state == .folded ? 54 : 307)
-        updateLayout()
         updateUI()
         contentView.layoutIfNeeded()
     }
@@ -57,6 +59,11 @@ private extension GoalCollectionViewCell {
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
+        stackView.axis = .vertical
+        [nottodoStackView, goalStackView].forEach {
+            $0.axis = .horizontal
+            $0.spacing = 5
+        }
         
         exampleLabel.do {
             $0.text = I18N.example
@@ -89,62 +96,50 @@ private extension GoalCollectionViewCell {
     }
     
     func setLayout() {
-        contentView.addSubviews(titleLabel, subTitleLabel, addMissionTextField,
-                    exampleLabel, nottodoTag, exampleNottodoLabel,
-                    goalTag, exampleGoalLabel)
+        stackView.addArrangedSubviews(titleLabel, subTitleLabel, addMissionTextField, exampleLabel, nottodoStackView, goalStackView)
+        nottodoStackView.addArrangedSubviews(nottodoTag, exampleNottodoLabel)
+        goalStackView.addArrangedSubviews(goalTag, exampleGoalLabel)
+        contentView.addSubviews(stackView)
         
-        updateLayout()
-        updateUI()
-    }
-    
-    private func updateLayout() {
-        titleLabel.snp.makeConstraints {
+        stackView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(16)
-            $0.leading.equalToSuperview().inset(21)
+            $0.leading.trailing.equalToSuperview().inset(22)
         }
         
-        subTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
-            $0.leading.equalToSuperview().inset(23)
+        goalStackView.snp.makeConstraints {
+            $0.width.equalTo(186)
         }
         
-//        let textFieldHeight = fold == .folded ? 0 : 48
-        addMissionTextField.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(25)
-            $0.directionalHorizontalEdges.equalToSuperview().inset(23)
-            $0.height.equalTo(48)
-        }
-        
-        exampleLabel.snp.makeConstraints {
-            $0.top.equalTo(addMissionTextField.snp.bottom).offset(13)
-            $0.leading.equalToSuperview().inset(25)
+        stackView.do {
+            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(25, after: subTitleLabel)
+            $0.setCustomSpacing(13, after: addMissionTextField)
+            $0.setCustomSpacing(8, after: exampleLabel)
+            $0.setCustomSpacing(5, after: nottodoStackView)
         }
         
         nottodoTag.snp.makeConstraints {
-            $0.top.equalTo(exampleLabel.snp.bottom).offset(8)
-            $0.leading.equalToSuperview().inset(23)
-        }
-        
-        exampleNottodoLabel.snp.makeConstraints {
-            $0.centerY.equalTo(nottodoTag.snp.centerY)
-            $0.leading.equalTo(nottodoTag.snp.trailing).offset(5)
+            $0.width.equalTo(58)
         }
         
         goalTag.snp.makeConstraints {
-            $0.top.equalTo(nottodoTag.snp.bottom).offset(5)
-            $0.leading.equalTo(nottodoTag.snp.leading)
+            $0.width.equalTo(47)
         }
         
-        exampleGoalLabel.snp.makeConstraints {
-            $0.centerY.equalTo(goalTag.snp.centerY)
-            $0.leading.equalTo(goalTag.snp.trailing).offset(5)
+        subTitleLabel.snp.makeConstraints {
+            $0.height.equalTo(60)
+        }
+        
+        addMissionTextField.snp.makeConstraints {
+            $0.height.equalTo(49)
         }
     }
     
     private func updateUI() {
         let isHidden: Bool = (fold == .folded)
         
-        [titleLabel, subTitleLabel, addMissionTextField, exampleLabel, nottodoTag,
-         exampleNottodoLabel, goalTag, exampleGoalLabel].forEach { $0.isHidden = isHidden }
+        [subTitleLabel, addMissionTextField, exampleLabel, nottodoStackView, goalStackView].forEach { $0.isHidden = isHidden }
+        
+        titleLabel.setTitleColor(isHidden)
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
@@ -26,7 +26,12 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private var addMissionTextField = AddMissionTextFieldView(textMaxCount: 20)
     private let historyLabel = UILabel()
     private let stackView = UIStackView()
+    private let foldStackView = UIStackView()
+    private let paddingView = UIView()
     private lazy var historyCollectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    
+    private var currentValue: String?
+    private let enterMessage = UILabel()
     
     // MARK: Life Cycle
     
@@ -64,16 +69,28 @@ extension NottodoCollectionViewCell {
         historyCollectionView.backgroundColor = .clear
         historyCollectionView.indicatorStyle = .white
         stackView.axis = .vertical
+        foldStackView.do {
+            $0.axis = .horizontal
+            $0.distribution = .fill
+            $0.spacing = 22
+        }
         
         historyLabel.do {
             $0.font = .Pretendard(.regular, size: 14)
             $0.text = I18N.missionHistoryLabel
             $0.textColor = .gray4
         }
+        
+        enterMessage.do {
+            $0.text = I18N.enterMessage
+            $0.textColor = .gray3
+            $0.font = .Pretendard(.regular, size: 15)
+        }
     }
     
     private func setLayout() {
-        stackView.addArrangedSubviews(titleLabel, subTitleLabel, addMissionTextField,
+        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView)
+        stackView.addArrangedSubviews(foldStackView, subTitleLabel, addMissionTextField,
                                       historyLabel, historyCollectionView)
         
         contentView.addSubviews(stackView)
@@ -84,13 +101,13 @@ extension NottodoCollectionViewCell {
         }
         
         stackView.do {
-            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(10, after: foldStackView)
             $0.setCustomSpacing(19, after: subTitleLabel)
             $0.setCustomSpacing(11, after: addMissionTextField)
             $0.setCustomSpacing(6, after: historyLabel)
             $0.setCustomSpacing(32, after: historyCollectionView)
         }
-        
+    
         subTitleLabel.snp.makeConstraints {
             $0.height.equalTo(30)
         }
@@ -108,7 +125,7 @@ extension NottodoCollectionViewCell {
         let isHidden: Bool = (fold == .folded)
         
         [subTitleLabel, addMissionTextField, historyLabel, historyCollectionView].forEach { $0.isHidden = isHidden }
-        
+        enterMessage.isHidden = !isHidden
         titleLabel.setTitleColor(isHidden)
     }
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
@@ -25,6 +25,7 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
                                               colorText: I18N.nottodo)
     private var addMissionTextField = AddMissionTextFieldView(textMaxCount: 20)
     private let historyLabel = UILabel()
+    private let stackView = UIStackView()
     private lazy var historyCollectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
     
     // MARK: Life Cycle
@@ -36,7 +37,7 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         registerCell()
         setLayout()
     }
-
+    
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -45,37 +46,24 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     func setFoldState(_ state: FoldState) {
         fold = state
         missionCellHeight?(state == .folded ? 54 : 347)
-        updateLayout()
         updateUI()
-        contentView.layoutIfNeeded()
+        layoutIfNeeded()
     }
     
-//    func calculateCellHeight(in state: FoldState) -> CGFloat {
-//        var cellHeight: CGFloat = 0
-//
-//        let itemWidth = self.bounds.width
-//        let titleLabelHeight = calculateLabelHeight(titleLabel.text, font: titleLabel.font, width: itemWidth)
-//        let subTitleLabelHeight = calculateLabelHeight(subTitleLabel.text, font: subTitleLabel.font, width: itemWidth)
-//        let textFieldViewHeight: CGFloat = 48
-//        let historyLabelHeight = calculateLabelHeight(historyLabel.text, font: historyLabel.font, width: itemWidth)
-//        var historyCollectionViewHeight: CGFloat = CGFloat(37 * MissionHistoryModel.items.count)
-//        historyCollectionViewHeight = historyCollectionViewHeight > 134 ? 134 : historyCollectionViewHeight
-//        let spacing: CGFloat = 16 + 10 + 24 + 11 + 6 + 32
-//
-//        cellHeight = titleLabelHeight + subTitleLabelHeight + textFieldViewHeight + historyLabelHeight + historyCollectionViewHeight + spacing
- //       return state == .folded ? 200 : 500
- //   }
-
+    func getText() -> String {
+        return addMissionTextField.getTextFieldText()
+    }
 }
 
 extension NottodoCollectionViewCell {
-    func setUI() {
+    private func setUI() {
         backgroundColor = .gray1
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
         historyCollectionView.backgroundColor = .clear
         historyCollectionView.indicatorStyle = .white
+        stackView.axis = .vertical
         
         historyLabel.do {
             $0.font = .Pretendard(.regular, size: 14)
@@ -85,47 +73,43 @@ extension NottodoCollectionViewCell {
     }
     
     private func setLayout() {
-        contentView.addSubviews(titleLabel, subTitleLabel, addMissionTextField,
-                    historyLabel, historyCollectionView)
+        stackView.addArrangedSubviews(titleLabel, subTitleLabel, addMissionTextField,
+                                      historyLabel, historyCollectionView)
         
-        updateUI()
-        updateLayout()
-    }
-    
-    private func updateLayout() {
-        titleLabel.snp.remakeConstraints {
+        contentView.addSubviews(stackView)
+        
+        stackView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(16)
-            $0.leading.equalToSuperview().inset(21)
+            $0.leading.trailing.equalToSuperview().inset(22)
         }
         
-        subTitleLabel.snp.remakeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
-            $0.leading.equalToSuperview().inset(23)
+        stackView.do {
+            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(19, after: subTitleLabel)
+            $0.setCustomSpacing(11, after: addMissionTextField)
+            $0.setCustomSpacing(6, after: historyLabel)
+            $0.setCustomSpacing(32, after: historyCollectionView)
         }
         
-//        let textFieldHeight = (fold == .folded) ? 0 : 48
-        addMissionTextField.snp.remakeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(25)
-            $0.directionalHorizontalEdges.equalToSuperview().inset(23)
-            $0.height.equalTo(48)
+        subTitleLabel.snp.makeConstraints {
+            $0.height.equalTo(30)
+        }
+        
+        addMissionTextField.snp.makeConstraints {
+            $0.height.equalTo(49)
         }
 
-        historyLabel.snp.remakeConstraints {
-            $0.top.equalTo(addMissionTextField.snp.bottom).offset(11)
-            $0.leading.equalToSuperview().inset(24)
-        }
-
-        historyCollectionView.snp.remakeConstraints {
-            $0.top.equalTo(historyLabel.snp.bottom).offset(6)
-            $0.directionalHorizontalEdges.equalToSuperview().inset(28)
-            $0.bottom.equalToSuperview().inset(32)
+        historyCollectionView.snp.makeConstraints {
+            $0.height.equalTo(134)
         }
     }
     
     private func updateUI() {
         let isHidden: Bool = (fold == .folded)
         
-        [titleLabel, subTitleLabel, addMissionTextField, historyLabel, historyCollectionView].forEach { $0.isHidden = isHidden }
+        [subTitleLabel, addMissionTextField, historyLabel, historyCollectionView].forEach { $0.isHidden = isHidden }
+        
+        titleLabel.setTitleColor(isHidden)
     }
     
     private func layout() -> UICollectionViewFlowLayout {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
@@ -26,6 +26,7 @@ final class SituationCollectionViewCell: UICollectionViewCell, AddMissionMenu {
                                               colorText: I18N.situation)
     private var addMissionTextField = AddMissionTextFieldView(textMaxCount: 10)
     private let recommendKeywordLabel = UILabel()
+    private let stackView = UIStackView()
     private lazy var recommendCollectionView = UICollectionView(frame: .zero, collectionViewLayout: CollectionViewLeftAlignLayout())
     
     // MARK: Life Cycle
@@ -47,11 +48,9 @@ final class SituationCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     func setFoldState(_ state: FoldState) {
         fold = state
         missionCellHeight?(state == .folded ? 54 : 314)
-        updateLayout()
         updateUI()
         contentView.layoutIfNeeded()
     }
-
 }
 
 private extension SituationCollectionViewCell {
@@ -60,6 +59,7 @@ private extension SituationCollectionViewCell {
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
+        stackView.axis = .vertical
         
         recommendCollectionView.do {
             $0.backgroundColor = .clear
@@ -74,45 +74,42 @@ private extension SituationCollectionViewCell {
     }
     
     func setLayout() {
-        contentView.addSubviews(titleLabel, subTitleLabel, addMissionTextField,
-                    recommendKeywordLabel, recommendCollectionView)
-        updateLayout()
-        updateUI()
-    }
-    
-    private func updateLayout() {
-        titleLabel.snp.remakeConstraints {
+        stackView.addArrangedSubviews(titleLabel, subTitleLabel, addMissionTextField,
+                                      recommendKeywordLabel, recommendCollectionView)
+        contentView.addSubviews(stackView)
+        
+        stackView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(16)
-            $0.leading.equalToSuperview().inset(21)
+            $0.leading.trailing.equalToSuperview().inset(22)
         }
         
-        subTitleLabel.snp.remakeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
-            $0.leading.equalToSuperview().inset(23)
+        stackView.do {
+            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(25, after: subTitleLabel)
+            $0.setCustomSpacing(14, after: addMissionTextField)
+            $0.setCustomSpacing(10, after: recommendKeywordLabel)
+            $0.setCustomSpacing(29, after: recommendCollectionView)
         }
         
-        addMissionTextField.snp.remakeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom).offset(25)
-            $0.directionalHorizontalEdges.equalToSuperview().inset(23)
-            $0.height.equalTo(48)
+        subTitleLabel.snp.makeConstraints {
+            $0.height.equalTo(60)
         }
-
-        recommendKeywordLabel.snp.remakeConstraints {
-            $0.top.equalTo(addMissionTextField.snp.bottom).offset(14)
-            $0.leading.equalToSuperview().inset(25)
+        
+        addMissionTextField.snp.makeConstraints {
+            $0.height.equalTo(49)
         }
-
-        recommendCollectionView.snp.remakeConstraints {
-            $0.top.equalTo(recommendKeywordLabel.snp.bottom).offset(10)
-            $0.directionalHorizontalEdges.equalToSuperview().inset(23)
-            $0.bottom.equalToSuperview().inset(29)
+        
+        recommendCollectionView.snp.makeConstraints {
+            $0.height.equalTo(60)
         }
     }
     
     private func updateUI() {
         let isHidden: Bool = (fold == .folded)
         
-        [titleLabel, subTitleLabel, addMissionTextField, recommendKeywordLabel, recommendCollectionView].forEach { $0.isHidden = isHidden }
+        [subTitleLabel, addMissionTextField, recommendKeywordLabel, recommendCollectionView].forEach { $0.isHidden = isHidden }
+        
+        titleLabel.setTitleColor(isHidden)
     }
     
     func registerCell() {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
@@ -27,6 +27,9 @@ final class SituationCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private var addMissionTextField = AddMissionTextFieldView(textMaxCount: 10)
     private let recommendKeywordLabel = UILabel()
     private let stackView = UIStackView()
+    private let foldStackView = UIStackView()
+    private let enterMessage = UILabel()
+    private let paddingView = UIView()
     private lazy var recommendCollectionView = UICollectionView(frame: .zero, collectionViewLayout: CollectionViewLeftAlignLayout())
     
     // MARK: Life Cycle
@@ -60,6 +63,11 @@ private extension SituationCollectionViewCell {
         layer.cornerRadius = 12
         layer.borderWidth = 1
         stackView.axis = .vertical
+        foldStackView.do {
+            $0.axis = .horizontal
+            $0.distribution = .fill
+            $0.spacing = 35
+        }
         
         recommendCollectionView.do {
             $0.backgroundColor = .clear
@@ -71,10 +79,17 @@ private extension SituationCollectionViewCell {
             $0.textColor = .white
             $0.font = .Pretendard(.medium, size: 14)
         }
+        
+        enterMessage.do {
+            $0.text = I18N.enterMessage
+            $0.textColor = .gray3
+            $0.font = .Pretendard(.regular, size: 15)
+        }
     }
     
     func setLayout() {
-        stackView.addArrangedSubviews(titleLabel, subTitleLabel, addMissionTextField,
+        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView)
+        stackView.addArrangedSubviews(foldStackView, subTitleLabel, addMissionTextField,
                                       recommendKeywordLabel, recommendCollectionView)
         contentView.addSubviews(stackView)
         
@@ -84,7 +99,7 @@ private extension SituationCollectionViewCell {
         }
         
         stackView.do {
-            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(10, after: foldStackView)
             $0.setCustomSpacing(25, after: subTitleLabel)
             $0.setCustomSpacing(14, after: addMissionTextField)
             $0.setCustomSpacing(10, after: recommendKeywordLabel)
@@ -108,7 +123,7 @@ private extension SituationCollectionViewCell {
         let isHidden: Bool = (fold == .folded)
         
         [subTitleLabel, addMissionTextField, recommendKeywordLabel, recommendCollectionView].forEach { $0.isHidden = isHidden }
-        
+        enterMessage.isHidden = !isHidden
         titleLabel.setTitleColor(isHidden)
     }
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Components/AddMissionLabel/AddMissionLabel.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Components/AddMissionLabel/AddMissionLabel.swift
@@ -31,6 +31,10 @@ final class TitleLabel: UILabel {
         font = .Pretendard(.regular, size: 15)
         textColor = .green1
     }
+    
+    func setTitleColor(_ isFold: Bool) {
+        textColor = isFold ? .gray4 : .green1
+    }
 }
 
 final class SubTitleLabel: UILabel {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -64,6 +64,10 @@ final class AddMissionViewController: UIViewController {
     func setActionLabel(_ text: String) {
         actionLabel = text
     }
+    
+    func setSituationLabel(_ text: String) {
+        situationLabel = text
+    }
 }
 
 private extension AddMissionViewController {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/Cells/RecommendActionCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/Cells/RecommendActionCollectionViewCell.swift
@@ -101,5 +101,4 @@ extension RecommendActionCollectionViewCell {
     func configure(model: RecommendActions) {
         titleLabel.text = model.name
     }
-    
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/Cells/RecommendActionHeaderView.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/Cells/RecommendActionHeaderView.swift
@@ -140,4 +140,8 @@ extension RecommendActionHeaderView {
     func getTitle() -> String {
         return titleLabel.text ?? ""
     }
+    
+    func getSituation() -> String {
+        return tagLabel.text ?? ""
+    }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
@@ -18,6 +18,7 @@ class RecommendActionViewController: UIViewController {
     var bodyImageUrl: UIImage?
     var nottodoTitle: String?
     var actionLabel: String?
+    var situationLabel: String?
     
     // MARK: - UI Components
     
@@ -54,6 +55,7 @@ extension RecommendActionViewController {
         let nextViewController = AddMissionViewController()
         nextViewController.setNottodoLabel(nottodoTitle ?? "")
         nextViewController.setActionLabel(actionLabel ?? "")
+        nextViewController.setSituationLabel(situationLabel ?? "")
         navigationController?.pushViewController(nextViewController, animated: true)
     }
 }
@@ -212,6 +214,7 @@ extension RecommendActionViewController: UICollectionViewDataSource {
                 guard let data = response.data else { return }
                 headerView.configure(tag: self?.tagLabelText, title: data.title, image: self?.bodyImageUrl)
                 self?.nottodoTitle = headerView.getTitle()
+                self?.situationLabel = headerView.getSituation()
             }
             
             return headerView
@@ -220,6 +223,7 @@ extension RecommendActionViewController: UICollectionViewDataSource {
             footerView.clickedNextButton = { [weak self] in
                 let nextViewContoller = AddMissionViewController()
                 nextViewContoller.setNottodoLabel(self?.nottodoTitle ?? "")
+                nextViewContoller.setSituationLabel(self?.situationLabel ?? "")
                 self?.navigationController?.pushViewController(nextViewContoller, animated: true)
             }
             return footerView


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 추천뷰에서 생성뷰 화면전환 시 상황 데이터도 ViewController에 넘겨주었습니다.
- fold, unfold 상태에 따른 UI를 구현하였습니다.

## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 텍스트필드에 데이터가 존재하는 채로 토글이 닫힌 경우, 텍스트필드에 데이터가 존재하지 않은 채로 토글이 닫힌 경우, 토글이 열린 경우 세 가지 케이스에 따라 UI 수정이 필요합니다.
- 해당 부분은 새 브랜치에서 진행하겠습니다.


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   토글 닫혔을 때 UI 구현    |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/a5c91514-1be8-4363-888d-8f863a566144" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #91
