### PR TITLE
[Design] #93 - 생성뷰 셀 상태에 따른 세 가지 UI 상태 구현

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
+++ b/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
@@ -1417,7 +1417,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "nottodo.iOS-NOTTODO";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1450,7 +1450,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.1;
+				MARKETING_VERSION = 0.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "nottodo.iOS-NOTTODO";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
@@ -14,9 +14,10 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     
     // MARK: - Properties
     
-    var missionCellHeight: ((CGFloat) -> Void)?
-    private var fold: FoldState = .folded
     static let identifier = "ActionCollectionViewCell"
+    var missionCellHeight: ((CGFloat) -> Void)?
+    var missionTextData: ((String) -> Void)?
+    private var fold: FoldState = .folded
     
     // MARK: - UI Components
     
@@ -28,12 +29,14 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private let exampleNottodo = UILabel()
     private let exampleActionOne = UILabel()
     private let exampleActionTwo = UILabel()
+    
     private let stackView = UIStackView()
     private let exampleStackView = UIStackView()
-    
     private let foldStackView = UIStackView()
-    private let enterMessage = UILabel()
     private let paddingView = UIView()
+    
+    private let checkImage = UIImageView()
+    private let enterMessage = UILabel()
     private let optionLabel = UILabel()
     
     // MARK: - Life Cycle
@@ -55,6 +58,26 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         setKeyboardReturnType()
         contentView.layoutIfNeeded()
     }
+    
+    func setCellData(_ text: String) {
+        if text.isEmpty {
+            enterMessage.text = I18N.enterMessage
+            enterMessage.textColor = .gray3
+            enterMessage.font = .Pretendard(.regular, size: 15)
+        } else {
+            enterMessage.text = text
+            enterMessage.textColor = .white
+            enterMessage.font = .Pretendard(.medium, size: 15)
+        }
+        
+        if fold == .unfolded {
+            [checkImage, optionLabel].forEach { $0.isHidden = true }
+        } else {
+            checkImage.isHidden = text.isEmpty
+            optionLabel.isHidden = !text.isEmpty
+        }
+        addMissionTextField.setText(text)
+    }
 }
 
 extension ActionCollectionViewCell {
@@ -63,6 +86,7 @@ extension ActionCollectionViewCell {
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
+        checkImage.image = .icChecked
         stackView.axis = .vertical
         foldStackView.do {
             $0.axis = .horizontal
@@ -109,7 +133,7 @@ extension ActionCollectionViewCell {
     }
     
     private func setLayout() {
-        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView, optionLabel)
+        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView, optionLabel, checkImage)
         exampleStackView.addArrangedSubviews(exampleLabel, exampleNottodo)
         stackView.addArrangedSubviews(foldStackView, subTitleLabel, addMissionTextField, exampleStackView, exampleActionOne, exampleActionTwo)
         contentView.addSubviews(stackView)
@@ -126,6 +150,10 @@ extension ActionCollectionViewCell {
             $0.setCustomSpacing(8, after: exampleStackView)
             $0.setCustomSpacing(6, after: exampleActionOne)
             $0.setCustomSpacing(31, after: exampleActionTwo)
+        }
+        
+        checkImage.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(18).priority(.high)
         }
         
         subTitleLabel.snp.makeConstraints {
@@ -153,6 +181,10 @@ extension ActionCollectionViewCell {
         
         backgroundColor = isHidden ? .clear : .gray1
         layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
+        
+        addMissionTextField.textFieldData = { string in
+            self.missionTextData?((string))
+        }
     }
     
     private func setKeyboardReturnType() {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
@@ -59,7 +59,7 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
 
 extension ActionCollectionViewCell {
     private func setUI() {
-        backgroundColor = .gray1
+        backgroundColor = .clear
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
@@ -150,6 +150,9 @@ extension ActionCollectionViewCell {
          exampleActionOne, exampleActionTwo].forEach { $0.isHidden = isHidden }
         [enterMessage, optionLabel].forEach { $0.isHidden = !isHidden }
         titleLabel.setTitleColor(isHidden)
+        
+        backgroundColor = isHidden ? .clear : .gray1
+        layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
     }
     
     private func setKeyboardReturnType() {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -17,7 +17,6 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         return
     }
     
-    
     // MARK: - Properties
     
     var missionCellHeight: ((CGFloat) -> Void)?

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -12,6 +12,11 @@ import Then
 import FSCalendar
 
 final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
+    var missionTextData: ((String) -> Void)?
+    func setCellData(_ text: String) {
+        return
+    }
+    
     
     // MARK: - Properties
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -51,7 +51,7 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
 private extension DateCollectionViewCell {
     
     private func setUI() {
-        backgroundColor = .gray1
+        backgroundColor = .clear
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
@@ -104,29 +104,6 @@ private extension DateCollectionViewCell {
             $0.directionalHorizontalEdges.equalToSuperview().inset(13)
         }
     }
-    
-    private func updateLayout() {
-        titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(16)
-            $0.leading.equalToSuperview().inset(21)
-        }
-        
-        subTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(10)
-            $0.leading.equalToSuperview().inset(23)
-        }
-        
-        warningLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(22)
-            $0.bottom.equalToSuperview().inset(18)
-        }
-        
-        calendarView.snp.makeConstraints {
-            $0.top.equalTo(subTitleLabel.snp.bottom)
-
-            $0.height.equalTo((UIScreen.main.bounds.size.width-60)*1.05)
-        }
-    }
 
     private func updateUI() {
         let isHidden: Bool = ( fold == .folded )
@@ -135,6 +112,9 @@ private extension DateCollectionViewCell {
         }
         
         titleLabel.setTitleColor(isHidden)
+        
+        backgroundColor = isHidden ? .clear : .gray1
+        layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
@@ -62,7 +62,7 @@ final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
 
 private extension GoalCollectionViewCell {
     func setUI() {
-        backgroundColor = .gray1
+        backgroundColor = .clear
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
@@ -160,5 +160,8 @@ private extension GoalCollectionViewCell {
         [subTitleLabel, addMissionTextField, exampleLabel, nottodoStackView, goalStackView].forEach { $0.isHidden = isHidden }
         [enterMessage, optionLabel].forEach { $0.isHidden = !isHidden }
         titleLabel.setTitleColor(isHidden)
+        
+        backgroundColor = isHidden ? .clear : .gray1
+        layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
@@ -11,12 +11,13 @@ import SnapKit
 import Then
 
 final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
-    
+
     // MARK: - Properties
     
-    var missionCellHeight: ((CGFloat) -> Void)?
-    private var fold: FoldState = .folded
     static let identifier = "GoalCollectionViewCell"
+    var missionCellHeight: ((CGFloat) -> Void)?
+    var missionTextData: ((String) -> Void)?
+    private var fold: FoldState = .folded
     
     // MARK: - UI Components
     
@@ -27,17 +28,21 @@ final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private let exampleLabel = UILabel()
     private let exampleNottodoLabel = UILabel()
     private let exampleGoalLabel = UILabel()
+    
     private let stackView = UIStackView()
     private let nottodoStackView = UIStackView()
     private let goalStackView = UIStackView()
     private let nottodoPaddingView = UIView()
     private let goalPaddingView = UIView()
+    
     private let nottodoTag = PaddingLabel(padding: UIEdgeInsets(top: 3, left: 13, bottom: 3, right: 13))
     private let goalTag = PaddingLabel(padding: UIEdgeInsets(top: 3, left: 13, bottom: 3, right: 13))
     
     private let foldStackView = UIStackView()
-    private let enterMessage = UILabel()
     private let paddingView = UIView()
+    
+    private let checkImage = UIImageView()
+    private let enterMessage = UILabel()
     private let optionLabel = UILabel()
     
     // MARK: - Life Cycle
@@ -58,6 +63,26 @@ final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         updateUI()
         contentView.layoutIfNeeded()
     }
+    
+    func setCellData(_ text: String) {
+        if text.isEmpty {
+            enterMessage.text = I18N.enterMessage
+            enterMessage.textColor = .gray3
+            enterMessage.font = .Pretendard(.regular, size: 15)
+        } else {
+            enterMessage.text = text
+            enterMessage.textColor = .white
+            enterMessage.font = .Pretendard(.medium, size: 15)
+        }
+        
+        if fold == .unfolded {
+            [checkImage, optionLabel].forEach { $0.isHidden = true }
+        } else {
+            checkImage.isHidden = text.isEmpty
+            optionLabel.isHidden = !text.isEmpty
+        }
+        addMissionTextField.setText(text)
+    }
 }
 
 private extension GoalCollectionViewCell {
@@ -66,6 +91,7 @@ private extension GoalCollectionViewCell {
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
+        checkImage.image = .icChecked
         stackView.axis = .vertical
         [nottodoStackView, goalStackView].forEach {
             $0.axis = .horizontal
@@ -125,7 +151,7 @@ private extension GoalCollectionViewCell {
         stackView.addArrangedSubviews(foldStackView, subTitleLabel, addMissionTextField, exampleLabel, nottodoStackView, goalStackView)
         nottodoStackView.addArrangedSubviews(nottodoTag, exampleNottodoLabel, nottodoPaddingView)
         goalStackView.addArrangedSubviews(goalTag, exampleGoalLabel, goalPaddingView)
-        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView, optionLabel)
+        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView, optionLabel, checkImage)
         contentView.addSubviews(stackView)
         
         stackView.snp.makeConstraints {
@@ -143,6 +169,10 @@ private extension GoalCollectionViewCell {
             $0.setCustomSpacing(13, after: addMissionTextField)
             $0.setCustomSpacing(8, after: exampleLabel)
             $0.setCustomSpacing(5, after: nottodoStackView)
+        }
+        
+        checkImage.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(18).priority(.high)
         }
         
         subTitleLabel.snp.makeConstraints {
@@ -163,5 +193,9 @@ private extension GoalCollectionViewCell {
         
         backgroundColor = isHidden ? .clear : .gray1
         layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
+        
+        addMissionTextField.textFieldData = { string in
+            self.missionTextData?((string))
+        }
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
@@ -14,9 +14,10 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     
     // MARK: - Properties
     
-    var missionCellHeight: ((CGFloat) -> Void)?
-    private var fold: FoldState = .folded
     static let identifier = "NottodoCollectionViewCell"
+    var missionCellHeight: ((CGFloat) -> Void)?
+    var missionTextData: ((String) -> Void)?
+    private var fold: FoldState = .folded
     
     // MARK: - UI Components
     
@@ -25,12 +26,13 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
                                               colorText: I18N.nottodo)
     private var addMissionTextField = AddMissionTextFieldView(textMaxCount: 20)
     private let historyLabel = UILabel()
+    private lazy var historyCollectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
+    
     private let stackView = UIStackView()
     private let foldStackView = UIStackView()
     private let paddingView = UIView()
-    private lazy var historyCollectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
     
-    private var currentValue: String?
+    private let checkImage = UIImageView()
     private let enterMessage = UILabel()
     
     // MARK: Life Cycle
@@ -55,8 +57,18 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         layoutIfNeeded()
     }
     
-    func getText() -> String {
-        return addMissionTextField.getTextFieldText()
+    func setCellData(_ text: String) {
+        if text.isEmpty {
+            enterMessage.text = I18N.enterMessage
+            enterMessage.textColor = .gray3
+            enterMessage.font = .Pretendard(.regular, size: 15)
+        } else {
+            enterMessage.text = text
+            enterMessage.textColor = .white
+            enterMessage.font = .Pretendard(.medium, size: 15)
+        }
+        checkImage.isHidden = text.isEmpty || fold == .unfolded
+        addMissionTextField.setText(text)
     }
 }
 
@@ -68,6 +80,7 @@ extension NottodoCollectionViewCell {
         layer.borderWidth = 1
         historyCollectionView.backgroundColor = .clear
         historyCollectionView.indicatorStyle = .white
+        checkImage.image = .icChecked
         stackView.axis = .vertical
         foldStackView.do {
             $0.axis = .horizontal
@@ -89,7 +102,7 @@ extension NottodoCollectionViewCell {
     }
     
     private func setLayout() {
-        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView)
+        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView, checkImage)
         stackView.addArrangedSubviews(foldStackView, subTitleLabel, addMissionTextField,
                                       historyLabel, historyCollectionView)
         
@@ -107,7 +120,11 @@ extension NottodoCollectionViewCell {
             $0.setCustomSpacing(6, after: historyLabel)
             $0.setCustomSpacing(32, after: historyCollectionView)
         }
-    
+        
+        checkImage.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(18).priority(.high)
+        }
+        
         subTitleLabel.snp.makeConstraints {
             $0.height.equalTo(30)
         }
@@ -115,7 +132,7 @@ extension NottodoCollectionViewCell {
         addMissionTextField.snp.makeConstraints {
             $0.height.equalTo(49)
         }
-
+        
         historyCollectionView.snp.makeConstraints {
             $0.height.equalTo(134)
         }
@@ -165,6 +182,7 @@ extension NottodoCollectionViewCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? MissionHistoryCollectionViewCell else { fatalError() }
         addMissionTextField.setText(cell.getText())
+        missionTextData?((addMissionTextField.getTextFieldText()))
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
@@ -147,6 +147,10 @@ extension NottodoCollectionViewCell {
         
         backgroundColor = isHidden ? .clear : .gray1
         layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
+        
+        addMissionTextField.textFieldData = { string in
+            self.missionTextData?((string))
+        }
     }
     
     private func layout() -> UICollectionViewFlowLayout {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
@@ -62,7 +62,7 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
 
 extension NottodoCollectionViewCell {
     private func setUI() {
-        backgroundColor = .gray1
+        backgroundColor = .clear
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
@@ -127,6 +127,9 @@ extension NottodoCollectionViewCell {
         [subTitleLabel, addMissionTextField, historyLabel, historyCollectionView].forEach { $0.isHidden = isHidden }
         enterMessage.isHidden = !isHidden
         titleLabel.setTitleColor(isHidden)
+        
+        backgroundColor = isHidden ? .clear : .gray1
+        layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
     }
     
     private func layout() -> UICollectionViewFlowLayout {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
@@ -14,10 +14,11 @@ final class SituationCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     
     // MARK: - Properties
     
+    static let identifier = "SituationCollectionViewCell"
     var missionCellHeight: ((CGFloat) -> Void)?
+    var missionTextData: ((String) -> Void)?
     private var fold: FoldState = .folded
     private var recommendSituatoinList: [RecommendSituationResponseDTO] = []
-    static let identifier = "SituationCollectionViewCell"
     
     // MARK: - UI Components
     
@@ -26,11 +27,14 @@ final class SituationCollectionViewCell: UICollectionViewCell, AddMissionMenu {
                                               colorText: I18N.situation)
     private var addMissionTextField = AddMissionTextFieldView(textMaxCount: 10)
     private let recommendKeywordLabel = UILabel()
+    private lazy var recommendCollectionView = UICollectionView(frame: .zero, collectionViewLayout: CollectionViewLeftAlignLayout())
+    
     private let stackView = UIStackView()
     private let foldStackView = UIStackView()
-    private let enterMessage = UILabel()
     private let paddingView = UIView()
-    private lazy var recommendCollectionView = UICollectionView(frame: .zero, collectionViewLayout: CollectionViewLeftAlignLayout())
+    
+    private let checkImage = UIImageView()
+    private let enterMessage = UILabel()
     
     // MARK: Life Cycle
     
@@ -54,6 +58,20 @@ final class SituationCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         updateUI()
         contentView.layoutIfNeeded()
     }
+    
+    func setCellData(_ text: String) {
+        if text.isEmpty {
+            enterMessage.text = I18N.enterMessage
+            enterMessage.textColor = .gray3
+            enterMessage.font = .Pretendard(.regular, size: 15)
+        } else {
+            enterMessage.text = text
+            enterMessage.textColor = .white
+            enterMessage.font = .Pretendard(.medium, size: 15)
+        }
+        checkImage.isHidden = text.isEmpty || fold == .unfolded
+        addMissionTextField.setText(text)
+    }
 }
 
 private extension SituationCollectionViewCell {
@@ -62,6 +80,7 @@ private extension SituationCollectionViewCell {
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
+        checkImage.image = .icChecked
         stackView.axis = .vertical
         foldStackView.do {
             $0.axis = .horizontal
@@ -88,7 +107,7 @@ private extension SituationCollectionViewCell {
     }
     
     func setLayout() {
-        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView)
+        foldStackView.addArrangedSubviews(titleLabel, enterMessage, paddingView, checkImage)
         stackView.addArrangedSubviews(foldStackView, subTitleLabel, addMissionTextField,
                                       recommendKeywordLabel, recommendCollectionView)
         contentView.addSubviews(stackView)
@@ -104,6 +123,10 @@ private extension SituationCollectionViewCell {
             $0.setCustomSpacing(14, after: addMissionTextField)
             $0.setCustomSpacing(10, after: recommendKeywordLabel)
             $0.setCustomSpacing(29, after: recommendCollectionView)
+        }
+        
+        checkImage.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(18).priority(.high)
         }
         
         subTitleLabel.snp.makeConstraints {
@@ -128,6 +151,10 @@ private extension SituationCollectionViewCell {
         
         backgroundColor = isHidden ? .clear : .gray1
         layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
+        
+        addMissionTextField.textFieldData = { string in
+            self.missionTextData?((string))
+        }
     }
     
     func registerCell() {
@@ -172,6 +199,7 @@ extension SituationCollectionViewCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? RecommendKeywordCollectionViewCell else { fatalError() }
         addMissionTextField.setText(cell.getText())
+        missionTextData?((addMissionTextField.getTextFieldText()))
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
@@ -58,7 +58,7 @@ final class SituationCollectionViewCell: UICollectionViewCell, AddMissionMenu {
 
 private extension SituationCollectionViewCell {
     func setUI() {
-        backgroundColor = .gray1
+        backgroundColor = .clear
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
@@ -125,6 +125,9 @@ private extension SituationCollectionViewCell {
         [subTitleLabel, addMissionTextField, recommendKeywordLabel, recommendCollectionView].forEach { $0.isHidden = isHidden }
         enterMessage.isHidden = !isHidden
         titleLabel.setTitleColor(isHidden)
+        
+        backgroundColor = isHidden ? .clear : .gray1
+        layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
     }
     
     func registerCell() {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Components/AddMissionTextFieldView/AddMissionTextFieldView.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Components/AddMissionTextFieldView/AddMissionTextFieldView.swift
@@ -10,11 +10,12 @@ import UIKit
 import SnapKit
 import Then
 
-final class AddMissionTextFieldView: UIView {
+final class AddMissionTextFieldView: UIView, textFiledDelegateProtocol {
     
     // MARK: - Properties
     
     private var textMaxCount: Int
+    var textFieldData: ((String) -> Void)?
     
     // MARK: - UI Components
     
@@ -51,6 +52,7 @@ final class AddMissionTextFieldView: UIView {
     }
     
     func downKeyboard() {
+        textFieldData?(getTextFieldText())
         addMissionTextField.resignFirstResponder()
     }
     
@@ -123,6 +125,7 @@ extension AddMissionTextFieldView: UITextFieldDelegate {
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textFieldData?(getTextFieldText())
         textField.resignFirstResponder()
         return true
     }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Components/AddMissionTextFieldView/AddMissionTextFieldView.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Components/AddMissionTextFieldView/AddMissionTextFieldView.swift
@@ -23,7 +23,7 @@ final class AddMissionTextFieldView: UIView {
     private let textFieldUnderLineView = UIView()
     
     // MARK: - Life Cycle
-  
+    
     init(textMaxCount: Int) {
         self.textMaxCount = textMaxCount
         super.init(frame: .zero)
@@ -56,6 +56,10 @@ final class AddMissionTextFieldView: UIView {
     
     func setReturnType( _ type: UIKeyboardType) {
         addMissionTextField.keyboardType = type
+    }
+    
+    func getTextFieldText() -> String {
+        return addMissionTextField.text ?? ""
     }
 }
 
@@ -106,9 +110,9 @@ extension AddMissionTextFieldView: UITextFieldDelegate {
     }
     
     func textFieldDidChangeSelection(_ textField: UITextField) {
-            guard let text = addMissionTextField.text else { return }
-            textCountLabel.text = "\(text.count)/\(textMaxCount)"
-        }
+        guard let text = addMissionTextField.text else { return }
+        textCountLabel.text = "\(text.count)/\(textMaxCount)"
+    }
     
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let currentText = textField.text ?? ""
@@ -119,7 +123,7 @@ extension AddMissionTextFieldView: UITextFieldDelegate {
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-            textField.resignFirstResponder()
-            return true
+        textField.resignFirstResponder()
+        return true
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Protocol/AddMissionProtocol.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Protocol/AddMissionProtocol.swift
@@ -9,5 +9,7 @@ import UIKit
 
 protocol AddMissionMenu {
     func setFoldState(_ state: FoldState)
+    func setCellData(_ text: String)
     var missionCellHeight: ((CGFloat) -> Void)? { get set }
+    var missionTextData: ((String) -> Void)? { get set }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Protocol/AddMissionProtocol.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Protocol/AddMissionProtocol.swift
@@ -13,3 +13,7 @@ protocol AddMissionMenu {
     var missionCellHeight: ((CGFloat) -> Void)? { get set }
     var missionTextData: ((String) -> Void)? { get set }
 }
+
+protocol textFiledDelegateProtocol {
+    var textFieldData: ((String) -> Void)? { get set }
+}

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -30,10 +30,7 @@ final class AddMissionViewController: UIViewController {
     private var foldStateList: [FoldState] = [.folded, .folded, .folded, .folded, .folded]
     
     private var heightList: [CGFloat] = [54, 54, 54, 54, 54]
-    private var nottodoLabel: String?
-    private var situationLabel: String?
-    private var actionLabel: String?
-    private var goalLabel: String?
+    private var nottodoInfoList: [String] = ["", "", "", "", ""]
     
     // MARK: - UI Components
     
@@ -58,20 +55,21 @@ final class AddMissionViewController: UIViewController {
     }
     
     func setNottodoLabel(_ text: String) {
-        nottodoLabel = text
-    }
-    
-    func setActionLabel(_ text: String) {
-        actionLabel = text
+        nottodoInfoList[1] = text
     }
     
     func setSituationLabel(_ text: String) {
-        situationLabel = text
+        nottodoInfoList[2] = text
     }
+    
+    func setActionLabel(_ text: String) {
+        nottodoInfoList[3] = text
+    }
+    
 }
 
-private extension AddMissionViewController {
-    func setUI() {
+extension AddMissionViewController {
+    private func setUI() {
         setAddButtonUI()
         view.backgroundColor = .ntdBlack
         separateView.backgroundColor = .gray2
@@ -100,14 +98,14 @@ private extension AddMissionViewController {
         }
     }
     
-    func setAddButtonUI() {
+    private func setAddButtonUI() {
         addButton.do {
             $0.isEnabled = isAdd
             $0.backgroundColor = isAdd ? .green2 : .gray2
         }
     }
     
-    func setLayout() {
+    private func setLayout() {
         navigationView.addSubviews(dismissButton, navigationTitle, addButton)
         view.addSubviews(navigationView, separateView, addMissionCollectionView)
         
@@ -145,7 +143,7 @@ private extension AddMissionViewController {
         }
     }
     
-    func layout() -> UICollectionViewFlowLayout {
+    private func layout() -> UICollectionViewFlowLayout {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
         layout.minimumLineSpacing = 14
@@ -153,12 +151,12 @@ private extension AddMissionViewController {
         return layout
     }
     
-    func setDelegate() {
+    private func setDelegate() {
         addMissionCollectionView.delegate = self
         addMissionCollectionView.dataSource = self
     }
     
-    func registerCell() {
+    private func registerCell() {
         addMissionCollectionView.register(DateCollectionViewCell.self, forCellWithReuseIdentifier: DateCollectionViewCell.identifier)
         addMissionCollectionView.register(NottodoCollectionViewCell.self,
                                           forCellWithReuseIdentifier: NottodoCollectionViewCell.identifier)
@@ -185,16 +183,15 @@ extension AddMissionViewController: UICollectionViewDataSource {
         guard var missionMenuCell = cell as? AddMissionMenu else {
             return UICollectionViewCell()
         }
+        missionMenuCell.missionTextData = { [weak self] string in
+            self?.nottodoInfoList[indexPath.row] = string
+        }
         
+        let currentCellInfo = nottodoInfoList[indexPath.row]
         let currentFoldState = foldStateList[indexPath.row]
         
-        missionMenuCell.missionCellHeight = { [weak self] height in
-            
-            self?.heightList[indexPath.row] = height
-            self?.addMissionCollectionView.collectionViewLayout.collectionView?.reloadItems(at: [indexPath])
-        }
-                
         missionMenuCell.setFoldState(currentFoldState)
+        missionMenuCell.setCellData(currentCellInfo)
 
         return cell
     }
@@ -218,7 +215,19 @@ extension AddMissionViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         addMissionCollectionView.scrollToItem(at: indexPath, at: .top, animated: true)
         foldStateList[indexPath.row].toggle()
-        addMissionCollectionView.reloadData()
+        
+        let cell = makeCollectionCell(collectionView: collectionView, for: indexPath)
+        guard var missionMenuCell = cell as? AddMissionMenu else {
+            return
+        }
+        
+        missionMenuCell.missionCellHeight = { [weak self] height in
+            self?.heightList[indexPath.row] = height
+        }
+        let currentFoldState = foldStateList[indexPath.row]
+        
+        missionMenuCell.setFoldState(currentFoldState)
+        addMissionCollectionView.collectionViewLayout.collectionView?.reloadItems(at: [indexPath])
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -65,7 +65,6 @@ final class AddMissionViewController: UIViewController {
     func setActionLabel(_ text: String) {
         nottodoInfoList[3] = text
     }
-    
 }
 
 extension AddMissionViewController {


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
1. 추천뷰 -> 생성뷰로 화면전환 시
- 모두 직접 입력하는 경우
- 낫투두와 상황을 추천뷰에서 선택하는 경우
- 낫투두, 상황, 실천행동을 추천뷰에서 선택하는 경우
데이터 전달 완료

2. 생성뷰에서 각 정보 입력 시,
- 셀 내부의 셀을 클릭해서 텍스트를 채우는 경우
- 키보드 입력 후 enter키로 키보드 dismiss 되는 경우
두 가지 경우에 대해 토글 닫힌 상태 UI 구현

## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 키보드 밖을 눌러서 dismiss 되는 경우는 셀 UI가 제대로 업데이트 되지 않습니다.

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   낫투두, 상황만 추천받는 경우    |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/7e0483b3-5a03-4bdf-960d-36d58ca4194f" width ="250">|
|   낫투두, 상황, 실천행동만 추천받는 경우    |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/edd43697-0d91-46df-b374-6b000a3d6e3b" width ="250">|
|   직접입력(키보드 입력, 셀 클릭)    |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/23fde170-f9b4-49d1-93b3-55476b3db638" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #93
