### PR TITLE
[Fix] #96 - 성취뷰 뷰전환 시 데이터 로드 수정

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Achievement/ViewControllers/AchievementViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Achievement/ViewControllers/AchievementViewController.swift
@@ -16,7 +16,6 @@ final class AchievementViewController: UIViewController {
     // MARK: - Properties
     
     private lazy var safeArea = self.view.safeAreaLayoutGuide
-   // private lazy var today: Date = { return Date() }()
     private var currentPage: Date? = Date()
     var count: Int?
     var dataSource: [String: Float] = [:] {
@@ -37,9 +36,10 @@ final class AchievementViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setUI()
-        setLayout()
+
         if let today = monthCalendar.calendar.today {
+            monthCalendar.yearMonthLabel.text = Utils.dateFormatterString(format: I18N.yearMonthTitle, date: today)
+            monthCalendar.calendar.currentPage = today
             requestMonthAPI(month: Utils.dateFormatterString(format: "yyyy-MM", date: today))
         }
     }
@@ -137,7 +137,6 @@ extension AchievementViewController: FSCalendarDelegate, FSCalendarDataSource, F
         self.currentPage = calendar.currentPage
         monthCalendar.yearMonthLabel.text = Utils.dateFormatterString(format: I18N.yearMonthTitle, date: calendar.currentPage)
         reloadMonthData(month: Utils.dateFormatterString(format: "yyyy-MM", date: calendar.currentPage))
-        
     }
         
     func calendar(_ calendar: FSCalendar, titleFor date: Date) -> String? {


### PR DESCRIPTION
## 🫧 작업한 내용

- 성취뷰로 뷰 전환시, 해당 달로 데이터 로드될 수 있게 수정했습니다.

## 🔫 PR Point



## 📸 스크린샷

![Jun-19-2023 12-52-52](https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/2b4ab9b2-f38a-407b-8911-a4f6a8c95cde)

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #96
