### PR TITLE
[Feat] #95 - 낫투두 날짜 데이터 전달 및 UI 구현

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
+++ b/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
@@ -1417,7 +1417,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.2;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "nottodo.iOS-NOTTODO";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1450,7 +1450,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.2;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "nottodo.iOS-NOTTODO";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Literals/Strings.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Literals/Strings.swift
@@ -94,6 +94,8 @@ struct I18N {
                           """
     static let enterMessage = "입력하세요..."
     static let option = "*선택"
+    static let today = "오늘"
+    static let tomorrow = "내일"
     
     /// MyInfo
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Literals/Strings.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Literals/Strings.swift
@@ -87,7 +87,7 @@ struct I18N {
     static let exampleNottodo = "유튜브 보지 않기"
     static let exampleGoal = "유튜브 프리미엄 구독 취소"
     static let exampleAction = "공부 중에 가방 안에 핸드폰 넣기"
-    static let dateWarning = "*일주일 이내의 일자만 선택 가능합니다"
+    static let dateWarning = "*달성 가능한 계획을 위해 다가올 일주일만 선택할 수 있어요"
     static let tipMessage = """
                           실천방법과 목표를 입력하면
                           낫투두 성공 확률이 더욱 올라가요!

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
@@ -59,13 +59,13 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         contentView.layoutIfNeeded()
     }
     
-    func setCellData(_ text: String) {
-        if text.isEmpty {
+    func setCellData(_ text: [String]) {
+        if text.first!.isEmpty {
             enterMessage.text = I18N.enterMessage
             enterMessage.textColor = .gray3
             enterMessage.font = .Pretendard(.regular, size: 15)
         } else {
-            enterMessage.text = text
+            enterMessage.text = text.first!
             enterMessage.textColor = .white
             enterMessage.font = .Pretendard(.medium, size: 15)
         }
@@ -73,10 +73,10 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         if fold == .unfolded {
             [checkImage, optionLabel].forEach { $0.isHidden = true }
         } else {
-            checkImage.isHidden = text.isEmpty
-            optionLabel.isHidden = !text.isEmpty
+            checkImage.isHidden = text.first!.isEmpty
+            optionLabel.isHidden = !text.first!.isEmpty
         }
-        addMissionTextField.setText(text)
+        addMissionTextField.setText(text.first!)
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/ActionCollectionViewCell.swift
@@ -16,7 +16,7 @@ final class ActionCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     
     static let identifier = "ActionCollectionViewCell"
     var missionCellHeight: ((CGFloat) -> Void)?
-    var missionTextData: ((String) -> Void)?
+    var missionTextData: (([String]) -> Void)?
     private var fold: FoldState = .folded
     
     // MARK: - UI Components
@@ -183,7 +183,7 @@ extension ActionCollectionViewCell {
         layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
         
         addMissionTextField.textFieldData = { string in
-            self.missionTextData?((string))
+            self.missionTextData?(([string]))
         }
     }
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -12,17 +12,15 @@ import Then
 import FSCalendar
 
 final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
-    var missionTextData: ((String) -> Void)?
-    func setCellData(_ text: String) {
-        return
-    }
     
     // MARK: - Properties
     
-    var missionCellHeight: ((CGFloat) -> Void)?
     static let identifier = "DateCollectionViewCell"
+    var missionCellHeight: ((CGFloat) -> Void)?
+    var missionTextData: ((String) -> Void)?
     private var fold: FoldState = .folded
     private lazy var today: Date = { return Date() }()
+    private lazy var tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: today)!
     
     // MARK: - UI Components
     
@@ -30,10 +28,15 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private let subTitleLabel = SubTitleLabel(subTitle: I18N.subDateTitle, colorText: nil)
     let calendarView = CalendarView(calendarScope: .month, scrollDirection: .horizontal)
     private let warningLabel = UILabel()
+    
     private let stackView = UIStackView()
+    private let foldStackView = UIStackView()
+    private let paddingView = UIView()
     
     private var calendarImage = UIImageView()
     private var dateLabel = UILabel()
+    private var dayLabel = UILabel()
+    private let foldStackViewPadding = UIView()
     
     // MARK: - Life Cycle
     override init(frame: CGRect) {
@@ -53,6 +56,20 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         updateUI()
         contentView.layoutIfNeeded()
     }
+    
+    func setCellData(_ text: [String]) {
+        let checkToday = text.first == Utils.dateFormatterString(format: "yyyy.MM.dd", date: today)
+        let checkTomorrow = text.first == Utils.dateFormatterString(format: "yyyy.MM.dd", date: tomorrow)
+        dateLabel.text = text.first
+        if checkToday {
+            dayLabel.text = I18N.today
+        } else if checkTomorrow {
+            dayLabel.text = I18N.tomorrow
+        } else {
+            dayLabel.isHidden = checkToday && checkTomorrow
+            paddingView.isHidden = !(checkToday && checkTomorrow)
+        }
+    }
 }
 
 private extension DateCollectionViewCell {
@@ -64,6 +81,20 @@ private extension DateCollectionViewCell {
         layer.borderWidth = 1
         calendarImage.image = .icCalendar
         stackView.axis = .vertical
+        foldStackView.do {
+            $0.axis = .horizontal
+            $0.distribution = .fill
+        }
+        
+        dayLabel.do {
+            $0.font = .Pretendard(.medium, size: 15)
+            $0.textColor = .white
+        }
+        
+        dateLabel.do {
+            $0.font = .Pretendard(.medium, size: 15)
+            $0.textColor = .gray4
+        }
         
         warningLabel.do {
             $0.text = I18N.dateWarning
@@ -80,7 +111,8 @@ private extension DateCollectionViewCell {
     }
     
     private func setLayout() {
-        stackView.addArrangedSubviews(titleLabel, subTitleLabel, calendarView, warningLabel)
+        foldStackView.addArrangedSubviews(titleLabel, dayLabel, paddingView, dateLabel, foldStackViewPadding, calendarImage)
+        stackView.addArrangedSubviews(foldStackView, subTitleLabel, calendarView, warningLabel)
         contentView.addSubviews(stackView)
         
         stackView.snp.makeConstraints {
@@ -89,13 +121,26 @@ private extension DateCollectionViewCell {
         }
         
         stackView.do {
-            $0.setCustomSpacing(10, after: titleLabel)
+            $0.setCustomSpacing(10, after: foldStackView)
             $0.setCustomSpacing(0, after: subTitleLabel)
             $0.setCustomSpacing(13, after: calendarView)
         }
         
-        titleLabel.snp.makeConstraints {
+        foldStackView.do {
+            $0.setCustomSpacing(36, after: titleLabel)
+        }
+        
+        foldStackView.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(6)
+        }
+        
+        paddingView.snp.makeConstraints {
+            $0.width.equalTo(9)
+        }
+        
+        calendarImage.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(24).priority(.high)
+            $0.size.equalTo(18)
         }
         
         subTitleLabel.snp.makeConstraints {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -28,10 +28,12 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     
     private let titleLabel = TitleLabel(title: I18N.date)
     private let subTitleLabel = SubTitleLabel(subTitle: I18N.subDateTitle, colorText: nil)
-    // 캘린더뷰가 들어갈 공간
     let calendarView = CalendarView(calendarScope: .month, scrollDirection: .horizontal)
     private let warningLabel = UILabel()
     private let stackView = UIStackView()
+    
+    private var calendarImage = UIImageView()
+    private var dateLabel = UILabel()
     
     // MARK: - Life Cycle
     override init(frame: CGRect) {
@@ -60,12 +62,14 @@ private extension DateCollectionViewCell {
         layer.borderColor = UIColor.gray3?.cgColor
         layer.cornerRadius = 12
         layer.borderWidth = 1
+        calendarImage.image = .icCalendar
         stackView.axis = .vertical
         
         warningLabel.do {
             $0.text = I18N.dateWarning
             $0.font = .Pretendard(.regular, size: 13)
             $0.textColor = .gray4
+            $0.numberOfLines = 0
         }
         
         calendarView.do {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -76,7 +76,6 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         if text.count == 1 {
             otherLabel.isHidden = true
         } else {
-            otherLabel.isHidden = false
             otherLabel.text = "외 \(text.count - 1)일"
         }
     }
@@ -175,7 +174,7 @@ private extension DateCollectionViewCell {
         [subTitleLabel, calendarView, warningLabel].forEach {
             $0.isHidden = isHidden
         }
-        [dayLabel, dateLabel, calendarImage].forEach { $0.isHidden = !isHidden }
+        [dayLabel, dateLabel, calendarImage, otherLabel].forEach { $0.isHidden = !isHidden }
         
         titleLabel.setTitleColor(isHidden)
         

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -22,6 +22,7 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     var missionCellHeight: ((CGFloat) -> Void)?
     static let identifier = "DateCollectionViewCell"
     private var fold: FoldState = .folded
+    private lazy var today: Date = { return Date() }()
     
     // MARK: - UI Components
     
@@ -108,7 +109,7 @@ private extension DateCollectionViewCell {
             $0.directionalHorizontalEdges.equalToSuperview().inset(13)
         }
     }
-
+    
     private func updateUI() {
         let isHidden: Bool = ( fold == .folded )
         [subTitleLabel, calendarView, warningLabel].forEach {
@@ -124,6 +125,32 @@ private extension DateCollectionViewCell {
 
 extension DateCollectionViewCell: FSCalendarDelegate {
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
-        calendarView.yearMonthLabel.text = Utils.dateFormatterString(format: I18N.yearMonthTitle, date: calendar.currentPage)        
+        calendarView.yearMonthLabel.text = Utils.dateFormatterString(format: I18N.yearMonthTitle, date: calendar.currentPage)
+    }
+    
+    func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
+        switch Calendar.current.compare(today, to: date, toGranularity: .day) {
+        case .orderedSame:
+            print("\(date) is the same as \(today)")
+            return true
+        case .orderedDescending:
+            print("\(date) is before \(today)")
+            return false
+        case .orderedAscending:
+            print("\(date) is after \(today)")
+            let sevenDays = Calendar.current.date(byAdding: .day, value: +6, to: Date())!
+            if date < sevenDays {
+                return true
+            }
+            return false
+        }
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, titleSelectionColorFor date: Date) -> UIColor? {
+        Utils.calendarTitleColor(today: today, date: date, selected: true)
+    }
+    
+    func calendar(_ calendar: FSCalendar, appearance: FSCalendarAppearance, titleDefaultColorFor date: Date) -> UIColor? {
+        Utils.calendarTitleColor(today: today, date: date, selected: false)
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -117,7 +117,8 @@ private extension DateCollectionViewCell {
         
         stackView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(16)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.equalToSuperview().inset(16)
+            $0.trailing.equalToSuperview().inset(24)
         }
         
         stackView.do {
@@ -130,16 +131,11 @@ private extension DateCollectionViewCell {
             $0.setCustomSpacing(36, after: titleLabel)
         }
         
-        foldStackView.snp.makeConstraints {
-            $0.leading.equalToSuperview().inset(6)
-        }
-        
         paddingView.snp.makeConstraints {
             $0.width.equalTo(9)
         }
         
         calendarImage.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(24).priority(.high)
             $0.size.equalTo(18)
         }
         
@@ -154,8 +150,7 @@ private extension DateCollectionViewCell {
         }
         
         calendarView.calendar.snp.updateConstraints {
-            $0.bottom.equalToSuperview()
-            $0.directionalHorizontalEdges.equalToSuperview().inset(13)
+            $0.bottom.directionalHorizontalEdges.equalToSuperview()
         }
     }
     
@@ -164,6 +159,7 @@ private extension DateCollectionViewCell {
         [subTitleLabel, calendarView, warningLabel].forEach {
             $0.isHidden = isHidden
         }
+        [dayLabel, dateLabel, calendarImage].forEach { $0.isHidden = !isHidden }
         
         titleLabel.setTitleColor(isHidden)
         

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
@@ -64,13 +64,13 @@ final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         contentView.layoutIfNeeded()
     }
     
-    func setCellData(_ text: String) {
-        if text.isEmpty {
+    func setCellData(_ text: [String]) {
+        if text.first!.isEmpty {
             enterMessage.text = I18N.enterMessage
             enterMessage.textColor = .gray3
             enterMessage.font = .Pretendard(.regular, size: 15)
         } else {
-            enterMessage.text = text
+            enterMessage.text = text.first!
             enterMessage.textColor = .white
             enterMessage.font = .Pretendard(.medium, size: 15)
         }
@@ -78,10 +78,10 @@ final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         if fold == .unfolded {
             [checkImage, optionLabel].forEach { $0.isHidden = true }
         } else {
-            checkImage.isHidden = text.isEmpty
-            optionLabel.isHidden = !text.isEmpty
+            checkImage.isHidden = text.first!.isEmpty
+            optionLabel.isHidden = !text.first!.isEmpty
         }
-        addMissionTextField.setText(text)
+        addMissionTextField.setText(text.first!)
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/GoalCollectionViewCell.swift
@@ -16,7 +16,7 @@ final class GoalCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     
     static let identifier = "GoalCollectionViewCell"
     var missionCellHeight: ((CGFloat) -> Void)?
-    var missionTextData: ((String) -> Void)?
+    var missionTextData: (([String]) -> Void)?
     private var fold: FoldState = .folded
     
     // MARK: - UI Components
@@ -195,7 +195,7 @@ private extension GoalCollectionViewCell {
         layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
         
         addMissionTextField.textFieldData = { string in
-            self.missionTextData?((string))
+            self.missionTextData?(([string]))
         }
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
@@ -16,7 +16,7 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     
     static let identifier = "NottodoCollectionViewCell"
     var missionCellHeight: ((CGFloat) -> Void)?
-    var missionTextData: ((String) -> Void)?
+    var missionTextData: (([String]) -> Void)?
     private var fold: FoldState = .folded
     
     // MARK: - UI Components
@@ -152,7 +152,7 @@ extension NottodoCollectionViewCell {
         layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
         
         addMissionTextField.textFieldData = { string in
-            self.missionTextData?((string))
+            self.missionTextData?(([string]))
         }
     }
     
@@ -189,7 +189,7 @@ extension NottodoCollectionViewCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? MissionHistoryCollectionViewCell else { fatalError() }
         addMissionTextField.setText(cell.getText())
-        missionTextData?((addMissionTextField.getTextFieldText()))
+        missionTextData?(([addMissionTextField.getTextFieldText()]))
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/NottodoCollectionViewCell.swift
@@ -57,18 +57,18 @@ final class NottodoCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         layoutIfNeeded()
     }
     
-    func setCellData(_ text: String) {
-        if text.isEmpty {
+    func setCellData(_ text: [String]) {
+        if text.first!.isEmpty {
             enterMessage.text = I18N.enterMessage
             enterMessage.textColor = .gray3
             enterMessage.font = .Pretendard(.regular, size: 15)
         } else {
-            enterMessage.text = text
+            enterMessage.text = text.first
             enterMessage.textColor = .white
             enterMessage.font = .Pretendard(.medium, size: 15)
         }
-        checkImage.isHidden = text.isEmpty || fold == .unfolded
-        addMissionTextField.setText(text)
+        checkImage.isHidden = text.first!.isEmpty || fold == .unfolded
+        addMissionTextField.setText(text.first!)
     }
 }
 
@@ -85,7 +85,6 @@ extension NottodoCollectionViewCell {
         foldStackView.do {
             $0.axis = .horizontal
             $0.distribution = .fill
-            $0.spacing = 22
         }
         
         historyLabel.do {
@@ -119,6 +118,10 @@ extension NottodoCollectionViewCell {
             $0.setCustomSpacing(11, after: addMissionTextField)
             $0.setCustomSpacing(6, after: historyLabel)
             $0.setCustomSpacing(32, after: historyCollectionView)
+        }
+        
+        foldStackView.do {
+            $0.setCustomSpacing(22, after: titleLabel)
         }
         
         checkImage.snp.makeConstraints {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
@@ -16,7 +16,7 @@ final class SituationCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     
     static let identifier = "SituationCollectionViewCell"
     var missionCellHeight: ((CGFloat) -> Void)?
-    var missionTextData: ((String) -> Void)?
+    var missionTextData: (([String]) -> Void)?
     private var fold: FoldState = .folded
     private var recommendSituatoinList: [RecommendSituationResponseDTO] = []
     
@@ -153,7 +153,7 @@ private extension SituationCollectionViewCell {
         layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor
         
         addMissionTextField.textFieldData = { string in
-            self.missionTextData?((string))
+            self.missionTextData?(([string]))
         }
     }
     
@@ -199,7 +199,7 @@ extension SituationCollectionViewCell: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? RecommendKeywordCollectionViewCell else { fatalError() }
         addMissionTextField.setText(cell.getText())
-        missionTextData?((addMissionTextField.getTextFieldText()))
+        missionTextData?(([addMissionTextField.getTextFieldText()]))
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/SituationCollectionViewCell.swift
@@ -59,18 +59,18 @@ final class SituationCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         contentView.layoutIfNeeded()
     }
     
-    func setCellData(_ text: String) {
-        if text.isEmpty {
+    func setCellData(_ text: [String]) {
+        if text.first!.isEmpty {
             enterMessage.text = I18N.enterMessage
             enterMessage.textColor = .gray3
             enterMessage.font = .Pretendard(.regular, size: 15)
         } else {
-            enterMessage.text = text
+            enterMessage.text = text.first
             enterMessage.textColor = .white
             enterMessage.font = .Pretendard(.medium, size: 15)
         }
-        checkImage.isHidden = text.isEmpty || fold == .unfolded
-        addMissionTextField.setText(text)
+        checkImage.isHidden = text.first!.isEmpty || fold == .unfolded
+        addMissionTextField.setText(text.first!)
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Protocol/AddMissionProtocol.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Protocol/AddMissionProtocol.swift
@@ -11,7 +11,7 @@ protocol AddMissionMenu {
     func setFoldState(_ state: FoldState)
     func setCellData(_ text: [String])
     var missionCellHeight: ((CGFloat) -> Void)? { get set }
-    var missionTextData: ((String) -> Void)? { get set }
+    var missionTextData: (([String]) -> Void)? { get set }
 }
 
 protocol textFiledDelegateProtocol {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Protocol/AddMissionProtocol.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Protocol/AddMissionProtocol.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol AddMissionMenu {
     func setFoldState(_ state: FoldState)
-    func setCellData(_ text: String)
+    func setCellData(_ text: [String])
     var missionCellHeight: ((CGFloat) -> Void)? { get set }
     var missionTextData: ((String) -> Void)? { get set }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -30,11 +30,10 @@ final class AddMissionViewController: UIViewController {
     private var foldStateList: [FoldState] = [.folded, .folded, .folded, .folded, .folded]
     
     private var heightList: [CGFloat] = [54, 54, 54, 54, 54]
+    private var dateList: [String] = []
     private var nottodoInfoList: [String] = ["", "", "", "", ""] {
         didSet {
-            isAdd =  !nottodoInfoList[0].isEmpty &&
-                !nottodoInfoList[1].isEmpty &&
-                !nottodoInfoList[2].isEmpty
+            isAdd = !nottodoInfoList[1].isEmpty && !nottodoInfoList[2].isEmpty
         }
     }
     
@@ -61,7 +60,7 @@ final class AddMissionViewController: UIViewController {
     }
     
     func setDate(_ date: String) {
-        nottodoInfoList[0] = date
+        dateList.append(date)
     }
     
     func setNottodoLabel(_ text: String) {
@@ -196,11 +195,16 @@ extension AddMissionViewController: UICollectionViewDataSource {
             self?.nottodoInfoList[indexPath.row] = string
         }
         
-        let currentCellInfo = nottodoInfoList[indexPath.row]
         let currentFoldState = foldStateList[indexPath.row]
+        let currentDateList = dateList
         
         missionMenuCell.setFoldState(currentFoldState)
-        missionMenuCell.setCellData(currentCellInfo)
+        if indexPath.row == 0 {
+            missionMenuCell.setCellData(currentDateList)
+        } else {
+            let currentCellInfo = nottodoInfoList[indexPath.row]
+            missionMenuCell.setCellData([currentCellInfo])
+        }
 
         return cell
     }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -30,7 +30,7 @@ final class AddMissionViewController: UIViewController {
     private var foldStateList: [FoldState] = [.folded, .folded, .folded, .folded, .folded]
     
     private var heightList: [CGFloat] = [54, 54, 54, 54, 54]
-    private var nottodoInfoList: [String] = ["test", "", "", "", ""] {
+    private var nottodoInfoList: [String] = ["", "", "", "", ""] {
         didSet {
             isAdd =  !nottodoInfoList[0].isEmpty &&
                 !nottodoInfoList[1].isEmpty &&
@@ -58,6 +58,10 @@ final class AddMissionViewController: UIViewController {
         registerCell()
         setDelegate()
         hideKeyboardWhenTappedAround()
+    }
+    
+    func setDate(_ date: String) {
+        nottodoInfoList[0] = date
     }
     
     func setNottodoLabel(_ text: String) {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -30,7 +30,13 @@ final class AddMissionViewController: UIViewController {
     private var foldStateList: [FoldState] = [.folded, .folded, .folded, .folded, .folded]
     
     private var heightList: [CGFloat] = [54, 54, 54, 54, 54]
-    private var nottodoInfoList: [String] = ["", "", "", "", ""]
+    private var nottodoInfoList: [String] = ["test", "", "", "", ""] {
+        didSet {
+            isAdd =  !nottodoInfoList[0].isEmpty &&
+                !nottodoInfoList[1].isEmpty &&
+                !nottodoInfoList[2].isEmpty
+        }
+    }
     
     // MARK: - UI Components
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -191,9 +191,6 @@ extension AddMissionViewController: UICollectionViewDataSource {
         guard var missionMenuCell = cell as? AddMissionMenu else {
             return UICollectionViewCell()
         }
-        missionMenuCell.missionTextData = { [weak self] string in
-            self?.nottodoInfoList[indexPath.row] = string
-        }
         
         let currentFoldState = foldStateList[indexPath.row]
         let currentDateList = dateList
@@ -201,8 +198,14 @@ extension AddMissionViewController: UICollectionViewDataSource {
         missionMenuCell.setFoldState(currentFoldState)
         if indexPath.row == 0 {
             missionMenuCell.setCellData(currentDateList)
+            missionMenuCell.missionTextData = { [weak self] string in
+                self?.dateList = string
+            }
         } else {
             let currentCellInfo = nottodoInfoList[indexPath.row]
+            missionMenuCell.missionTextData = { [weak self] string in
+                self?.nottodoInfoList[indexPath.row] = string.first!
+            }
             missionMenuCell.setCellData([currentCellInfo])
         }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -17,6 +17,7 @@ class HomeViewController: UIViewController {
     
     private var missionList: [DailyMissionResponseDTO] = []
     private var selectedDate: Date? // 눌렀을 떄 date - dailymissionAPI 호출 시 사용
+    private let dateFormatter = DateFormatter()
     private var percentage: Float?
     private var moveDate: String?
     private var current: Date? // 스와이프했을 때 일요일 date 구하기 위함 - weeklyAPI 호출 시 사용
@@ -82,6 +83,7 @@ extension HomeViewController {
     
     private func setUI() {
         view.backgroundColor = .ntdBlack
+        dateFormatter.dateFormat = "yyyy.MM.dd"
         
         weekCalendar.do {
             $0.calendar.delegate = self
@@ -259,7 +261,9 @@ extension HomeViewController: UICollectionViewDelegate {
 extension HomeViewController {
     @objc
     func addBtnTapped(_sender: UIButton) {
-        Utils.push(navigationController, RecommendViewController())
+        let nextViewController = RecommendViewController()
+        nextViewController.setSelectDate(dateFormatter.string(from: selectedDate ?? Date()))
+        Utils.push(navigationController, nextViewController)
     }
     @objc
     func todayBtnTapped(_sender: UIButton) {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
@@ -13,6 +13,7 @@ class RecommendViewController: UIViewController {
     
     var recommendResponse: RecommendResponseDTO?
     var recommendList: [RecommendResponseDTO] = []
+    private var selectDay: String?
 
     // MARK: - UI Components
     
@@ -39,6 +40,10 @@ class RecommendViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         requestRecommendAPI()
+    }
+    
+    func setSelectDate(_ date: String) {
+        selectDay = date
     }
 }
 
@@ -143,6 +148,7 @@ private extension RecommendViewController {
     @objc
     private func buttonTapped() {
         let nextViewController = AddMissionViewController()
+        nextViewController.setDate(selectDay ?? "")
         navigationController?.pushViewController(nextViewController, animated: true)
     }
 }
@@ -183,6 +189,7 @@ extension RecommendViewController: UICollectionViewDelegate {
             viewController.selectedIndex = selectedCell.id
             viewController.tagLabelText = selectedCell.tagLabel.text
             viewController.bodyImageUrl = selectedCell.bodyImage.image
+            viewController.setSelectDate(self.selectDay ?? "")
             
             self.navigationController?.pushViewController(viewController, animated: false)
         }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
@@ -19,6 +19,7 @@ class RecommendActionViewController: UIViewController {
     var nottodoTitle: String?
     var actionLabel: String?
     var situationLabel: String?
+    private var selectDay: String?
     
     // MARK: - UI Components
     
@@ -45,6 +46,10 @@ class RecommendActionViewController: UIViewController {
         super.viewWillAppear(animated)
         requestRecommendActionAPI()
     }
+    
+    func setSelectDate(_ date: String) {
+        selectDay = date
+    }
 }
 
 // MARK: - @objc
@@ -56,6 +61,7 @@ extension RecommendActionViewController {
         nextViewController.setNottodoLabel(nottodoTitle ?? "")
         nextViewController.setActionLabel(actionLabel ?? "")
         nextViewController.setSituationLabel(situationLabel ?? "")
+        nextViewController.setDate(selectDay ?? "")
         navigationController?.pushViewController(nextViewController, animated: true)
     }
 }
@@ -224,6 +230,7 @@ extension RecommendActionViewController: UICollectionViewDataSource {
                 let nextViewContoller = AddMissionViewController()
                 nextViewContoller.setNottodoLabel(self?.nottodoTitle ?? "")
                 nextViewContoller.setSituationLabel(self?.situationLabel ?? "")
+                nextViewContoller.setDate(self?.selectDay ?? "")
                 self?.navigationController?.pushViewController(nextViewContoller, animated: true)
             }
             return footerView


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 홈뷰 -> 추천뷰 -> 생성뷰 로 낫투두 생성 날짜 데이터 전달 구현
- 낫투두 날짜 선택에 따라 UI 분기처리 구현
1. 오늘 날짜 선택
2. 내일 날짜 선택
3. 오늘 날짜 외 다른 날짜 복수 선택
4. 내일 날짜 외 다른 날짜 복수 선택
5. 오늘, 내일 날짜를 제외한 날짜 선택
6. 오늘, 내일 날짜를 제외한 날짜 복수 선택

## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   분기처리 6가지 UI    |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/b79fcd7d-abaa-4b23-a2d7-aa92f723cacc" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #95
