### PR TITLE
[Fix] #118 - 온보딩 애니메이션 뷰 수정

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/Cell/OnboardingCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/Cell/OnboardingCollectionViewCell.swift
@@ -18,7 +18,8 @@ class OnboardingCollectionViewCell: UICollectionViewCell {
     
     override var isSelected: Bool {
         didSet {
-            contentView.layer.borderColor = isSelected ? UIColor.gray3?.cgColor : UIColor.clear.cgColor
+            contentView.layer.borderColor = isSelected ? UIColor.green1?.cgColor : UIColor.clear.cgColor
+            contentView.backgroundColor = isSelected ? .gray2 : .gray1
         }
     }
     
@@ -43,7 +44,7 @@ class OnboardingCollectionViewCell: UICollectionViewCell {
 
 extension OnboardingCollectionViewCell {
     private func setUI() {
-        contentView.backgroundColor = .gray2
+        contentView.backgroundColor = .gray1
         contentView.layer.cornerRadius = 10
         contentView.layer.masksToBounds = true
         contentView.layer.borderWidth = 1


### PR DESCRIPTION
## 🫧 작업한 내용

- 온보딩 뷰 선택시 border 색상 변경 
## 🔫 PR Point



## 📸 스크린샷


|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   GIF           |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/74491b1e-b98b-470e-b35d-2005c13257d5" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #
