### PR TITLE
[Fix] #116 - 로그인 로직 수정

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
@@ -23,10 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         KakaoSDK.initSDK(appKey: "f06c671df540ff4a8f8275f453368748")
         
-        // 낫투두 서버로부터 받은 토큰이 유효할 경우
-        // 토큰이 유효한지 확인할 방법이 없으므로 UserDefaults에 값이 있는 경우로 대체
         if KeychainUtil.getAccessToken() != "" {
-            // self.skipAuthView()
+            self.skipAuthView()
             print("토큰유효!!!!!")
         } else {
             // self.showAuthView()

--- a/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
            
-            let rootViewController = ValueOnboardingViewController()
+            let rootViewController = AuthViewController() // ValueOnboardingViewController()
             let navigationController = UINavigationController(rootViewController: rootViewController)
             navigationController.isNavigationBarHidden = true
             window.rootViewController = navigationController

--- a/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.overrideUserInterfaceStyle = UIUserInterfaceStyle.light
            
-            let rootViewController = AuthViewController() // ValueOnboardingViewController()
+            let rootViewController = ValueOnboardingViewController()
             let navigationController = UINavigationController(rootViewController: rootViewController)
             navigationController.isNavigationBarHidden = true
             window.rootViewController = navigationController

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/DefaultKeys.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/DefaultKeys.swift
@@ -19,9 +19,10 @@ enum LoginType {
 }
 
 struct DefaultKeys {
-    static let userId = "userId"
-    static let email = "email"
-    static let name = "name"
+    static let kakaoEmail = "kakaoEmail"
+    static let kakaoName = "kakaoName"
+    static let appleEmail = "appleEmail"
+    static let appleName = "appleName"
     static let isAppleLogin = "isAppleLogin"
     static let isKakaoLogin = "isKakaoLogin"
     static let socialToken = "socialToken"

--- a/iOS-NOTTODO/iOS-NOTTODO/Network/API/Auth/AuthAPI.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Network/API/Auth/AuthAPI.swift
@@ -19,8 +19,25 @@ final class AuthAPI {
     
     // MARK: - POST
     
-    func postAuth(social: String, socialToken: String, fcmToken: String, name: String, email: String, completion: @escaping (GeneralResponse<AuthResponseDTO>?) -> Void) {
-        authProvider.request(.auth(social: social, socialToken: socialToken, fcmToken: fcmToken, name: name, email: email)) { result in
+    func postKakaoAuth(social: String, socialToken: String, fcmToken: String, completion: @escaping (GeneralResponse<AuthResponseDTO>?) -> Void) {
+        authProvider.request(.kakaoAuth(social: social, socialToken: socialToken, fcmToken: fcmToken)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    guard let authData = try response.map(GeneralResponse<AuthResponseDTO>?.self) else { return }
+                    completion(authData)
+                } catch let err {
+                    print(err.localizedDescription, 500)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    func postAppleAuth(social: String, socialToken: String, fcmToken: String, name: String, completion: @escaping (GeneralResponse<AuthResponseDTO>?) -> Void) {
+        authProvider.request(.appleAuth(social: social, socialToken: socialToken, fcmToken: fcmToken, name: name)) { result in
             switch result {
             case .success(let response):
                 do {

--- a/iOS-NOTTODO/iOS-NOTTODO/Network/Service/Auth/AuthService.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Network/Service/Auth/AuthService.swift
@@ -10,7 +10,8 @@ import Foundation
 import Moya
 
 enum AuthService {
-    case auth(social: String, socialToken: String, fcmToken: String, name: String, email: String)
+    case kakaoAuth(social: String, socialToken: String, fcmToken: String)
+    case appleAuth(social: String, socialToken: String, fcmToken: String, name: String)
     case logout
     case withdrawal
 }
@@ -22,7 +23,7 @@ extension AuthService: TargetType {
     
     var path: String {
         switch self {
-        case .auth(let social, _, _, _, _):
+        case .kakaoAuth(let social, _, _), .appleAuth(let social, _, _, _):
             return URLConstant.auth + "/\(social)"
         case .logout:
             return URLConstant.authLogout
@@ -33,7 +34,7 @@ extension AuthService: TargetType {
     
     var method: Moya.Method {
         switch self {
-        case .auth:
+        case .kakaoAuth, .appleAuth:
             return .post
         case .logout:
             return .delete
@@ -43,8 +44,11 @@ extension AuthService: TargetType {
     }
     var task: Moya.Task {
         switch self {
-        case .auth(_, let socialToken, let fcmToken, let name, let email):
-            return .requestParameters(parameters: ["socialToken": socialToken, "fcmToken": fcmToken, "name": name, "email": email],
+        case .kakaoAuth(_, let socialToken, let fcmToken):
+            return .requestParameters(parameters: ["socialToken": socialToken, "fcmToken": fcmToken],
+                                      encoding: JSONEncoding.default)
+        case .appleAuth(_, let socialToken, let fcmToken, let name):
+            return .requestParameters(parameters: ["socialToken": socialToken, "fcmToken": fcmToken, "name": name],
                                       encoding: JSONEncoding.default)
         case .logout, .withdrawal:
             return .requestPlain
@@ -53,7 +57,7 @@ extension AuthService: TargetType {
     
     var headers: [String: String]? {
         switch self {
-        case .auth:
+        case .kakaoAuth, .appleAuth:
             return NetworkConstant.noTokenHeader
         case .logout, .withdrawal:
             return ["Content-Type": "application/json",

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
@@ -208,8 +208,8 @@ extension AuthViewController {
                 let name = user?.kakaoAccount?.name
                 let email = user?.kakaoAccount?.email
                 
-                KeychainUtil.setString(name, forKey: DefaultKeys.name)
-                KeychainUtil.setString(email, forKey: DefaultKeys.email)
+                KeychainUtil.setString(name, forKey: DefaultKeys.kakaoName)
+                KeychainUtil.setString(email, forKey: DefaultKeys.kakaoEmail)
                 KeychainUtil.setBool(false, forKey: DefaultKeys.isAppleLogin)
                 
                 AuthAPI.shared.postKakaoAuth(social: LoginType.Kakao.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken) { [weak self] result in
@@ -252,15 +252,15 @@ extension AuthViewController: ASAuthorizationControllerDelegate, ASAuthorization
                 }
             }
             
-            if let email = appleIDCredential.email {
-                KeychainUtil.setString(email, forKey: DefaultKeys.email)
-            }
-            
             let firstName = appleIDCredential.fullName?.givenName
             let lastName = appleIDCredential.fullName?.familyName
             if let firstName = firstName, let lastName = lastName {
                 let fullName = "\(lastName)\(firstName)"
-                KeychainUtil.setString(fullName, forKey: DefaultKeys.name)
+                KeychainUtil.setString(fullName, forKey: DefaultKeys.appleName)
+            }
+            
+            if let email = appleIDCredential.email {
+                KeychainUtil.setString(email, forKey: DefaultKeys.appleEmail)
             }
             
             KeychainUtil.setBool(true, forKey: DefaultKeys.isAppleLogin)

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
@@ -140,18 +140,7 @@ extension AuthViewController {
         }
         
     }
-    
-    private func requestAuthAPI(social: String, socialToken: String, fcmToken: String, name: String, email: String) {
-        AuthAPI.shared.postAuth(social: social, socialToken: socialToken, fcmToken: fcmToken, name: name, email: email) { [weak self] result in
-            guard self != nil else { return }
-            guard result != nil else { return }
-            // accessToken userDefault에 저장
-            guard let accessToken = result?.data?.accessToken else { return }
-            KeychainUtil.setAccessToken(accessToken)
-            self?.presentToHomeViewController()
-        }
-    }
-    
+        
     // MARK: - @objc Methods
     
     @objc func moreButtonTapped() {
@@ -223,7 +212,14 @@ extension AuthViewController {
                 KeychainUtil.setString(email, forKey: DefaultKeys.email)
                 KeychainUtil.setBool(false, forKey: DefaultKeys.isAppleLogin)
                 
-                self.requestAuthAPI(social: LoginType.Kakao.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken, name: KeychainUtil.getUsername(), email: KeychainUtil.getEmail())
+                AuthAPI.shared.postKakaoAuth(social: LoginType.Kakao.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken) { [weak self] result in
+                    guard self != nil else { return }
+                    guard result != nil else { return }
+                    
+                    guard let accessToken = result?.data?.accessToken else { return }
+                    KeychainUtil.setAccessToken(accessToken)
+                    self?.presentToHomeViewController()
+                }
             }
         }
     }
@@ -269,7 +265,14 @@ extension AuthViewController: ASAuthorizationControllerDelegate, ASAuthorization
             
             KeychainUtil.setBool(true, forKey: DefaultKeys.isAppleLogin)
 
-            self.requestAuthAPI(social: LoginType.Apple.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken, name: KeychainUtil.getUsername(), email: KeychainUtil.getEmail())
+            AuthAPI.shared.postAppleAuth(social: LoginType.Apple.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken, name: KeychainUtil.getUsername()) { [weak self] result in
+                guard self != nil else { return }
+                guard result != nil else { return }
+                
+                guard let accessToken = result?.data?.accessToken else { return }
+                KeychainUtil.setAccessToken(accessToken)
+                self?.presentToHomeViewController()
+            }
         default:
             break
         }


### PR DESCRIPTION
## 🫧 작업한 내용

로그인 로직 수정

## 🔫 PR Point

* 카카오 로그인과 애플 로그인을 분리하여 카카오는 socialToken, fcmToken, 애플은 socialToken, fcmToken, name 정보를 서버에 보내도록 수정했습니당
* 유저가 두 가지 소셜 로그인을 모두 시도한 경우 (ex. 카카오 로그아웃 후 애플 로그인) 각 소셜 간 name 및 email 정보가 꼬이는 상황을 방지하기 위해 기존 name, email UserDefaults를 kakaoName, kakaoEmail, appleName, appleEmail로 수정

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #116 
