### PR TITLE
[Feat] #132 - 특정 낫투두에 해당하는 날짜들 조회 API 연결

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Network/API/AddMission/AddMissionAPI.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Network/API/AddMission/AddMissionAPI.swift
@@ -21,6 +21,7 @@ final class AddMissionAPI {
     public private(set) var addMissionData: GeneralResponse<AddMissionResponseDTO>?
     public private(set) var updateMissionData: GeneralResponse<UpdateMissionResponseDTO>?
     public private(set) var recentMissionData: GeneralArrayResponse<RecentMissionResponseDTO>?
+    public private(set) var missionDatesData: GeneralArrayResponse<String>?
     
     // MARK: - GET
     
@@ -51,6 +52,24 @@ final class AddMissionAPI {
                     self.recentMissionData = try response.map(GeneralArrayResponse<RecentMissionResponseDTO>?.self)
                     guard let recentMissionData = self.recentMissionData else { return }
                     completion(recentMissionData)
+                } catch let err {
+                    print(err.localizedDescription, 500)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    func getMissionDates(id: Int, completion: @escaping (GeneralArrayResponse<String>?) -> Void) {
+        addMissionProvider.request(.missionDates(id: id)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    self.missionDatesData = try response.map(GeneralArrayResponse<String>?.self)
+                    guard let missionDatesData = self.missionDatesData else { return }
+                    completion(missionDatesData)
                 } catch let err {
                     print(err.localizedDescription, 500)
                 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Network/Service/AddMission/AddMissionService.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Network/Service/AddMission/AddMissionService.swift
@@ -14,6 +14,7 @@ enum AddMissionService {
     case addMission(title: String, situation: String, actions: [String]?, goal: String?, dates: [String])
     case updateMission(id: Int, title: String, situation: String, actions: [String]?, goal: String?)
     case recentMission
+    case missionDates(id: Int)
 }
 
 extension AddMissionService: TargetType {
@@ -31,12 +32,14 @@ extension AddMissionService: TargetType {
             return URLConstant.mission + "/\(id)"
         case .recentMission:
             return URLConstant.recentMission
+        case .missionDates(let id):
+            return URLConstant.mission + "/\(id)/dates"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .recommendSituation, .recentMission:
+        case .recommendSituation, .recentMission, .missionDates:
             return .get
         case .addMission:
             return .post
@@ -47,7 +50,7 @@ extension AddMissionService: TargetType {
     
     var task: Moya.Task {
         switch self {
-        case .recommendSituation, .recentMission:
+        case .recommendSituation, .recentMission, .missionDates:
             return .requestPlain
         case .addMission(let title, let situation, let actions, let goal, let dates):
             return .requestParameters(

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -64,8 +64,8 @@ final class AddMissionViewController: UIViewController {
         hideKeyboardWhenTappedAround()
     }
     
-    func setDate(_ date: String) {
-        dateList.append(date)
+    func setDate(_ date: [String]) {
+        dateList = date
     }
     
     func setNottodoLabel(_ text: String) {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/MissionDetailViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/MissionDetailViewController.swift
@@ -16,7 +16,7 @@ final class MissionDetailViewController: UIViewController {
     
     var deleteClosure: (() -> Void)?
     var moveDateClosure: ((_ date: String) -> Void)?
-    private var missionDate: String?
+    private var missionDate: [String]?
 
     private lazy var safeArea = self.view.safeAreaLayoutGuide
     enum Section {
@@ -45,12 +45,13 @@ final class MissionDetailViewController: UIViewController {
         register()
         setUI()
         setLayout()
+        requestGetMissionDates(id: userId ?? 0)
         setupDataSource()
         reloadData()
     }
     
     func setMissionDate(_ text: String) {
-        missionDate = text
+        missionDate = [text]
     }
 }
 
@@ -131,7 +132,7 @@ extension MissionDetailViewController {
                     guard let rootViewController = self.presentingViewController as? UINavigationController else { return }
                     updateMissionViewController.setMissionId(self.userId ?? 0)
                     updateMissionViewController.setViewType(.update)
-                    updateMissionViewController.setDate(self.missionDate ?? "")
+                    updateMissionViewController.setDate(self.missionDate ?? [])
                     updateMissionViewController.setNottodoLabel(self.detailModel.first!.title)
                     updateMissionViewController.setSituationLabel(self.detailModel.first!.situation)
                     updateMissionViewController.setGoalLabel(self.detailModel.first!.goal)
@@ -219,6 +220,16 @@ extension MissionDetailViewController {
                     self?.dismiss(animated: true)
                 } else {}
             }
+        }
+    }
+    
+    private func requestGetMissionDates(id: Int) {
+        AddMissionAPI.shared.getMissionDates(id: id) { [weak self] response in
+            guard self != nil else { return }
+            guard let response = response else { return }
+            
+            guard let data = response.data else { return }
+            self?.missionDate = data
         }
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
@@ -148,7 +148,7 @@ private extension RecommendViewController {
     @objc
     private func buttonTapped() {
         let nextViewController = AddMissionViewController()
-        nextViewController.setDate(selectDay ?? "")
+        nextViewController.setDate([selectDay ?? ""])
         navigationController?.pushViewController(nextViewController, animated: true)
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
@@ -61,7 +61,7 @@ extension RecommendActionViewController {
         nextViewController.setNottodoLabel(nottodoTitle ?? "")
         nextViewController.setActionLabel(actionLabel ?? "")
         nextViewController.setSituationLabel(situationLabel ?? "")
-        nextViewController.setDate(selectDay ?? "")
+        nextViewController.setDate([selectDay ?? ""])
         navigationController?.pushViewController(nextViewController, animated: true)
     }
 }
@@ -230,7 +230,7 @@ extension RecommendActionViewController: UICollectionViewDataSource {
                 let nextViewContoller = AddMissionViewController()
                 nextViewContoller.setNottodoLabel(self?.nottodoTitle ?? "")
                 nextViewContoller.setSituationLabel(self?.situationLabel ?? "")
-                nextViewContoller.setDate(self?.selectDay ?? "")
+                nextViewContoller.setDate([self?.selectDay ?? ""])
                 self?.navigationController?.pushViewController(nextViewContoller, animated: true)
             }
             return footerView


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 홈 -> 수정하기로 이동했을 때 특정 낫투두에 해당하는 날짜들 조회 API를 연결했습니다.


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   특정 낫투두에 해당하는 모든 날짜 조회     |<img width="897" alt="image" src="https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/c26f8261-5bca-42ad-85db-7e80c765cfcc"> |
|  뷰 GIF |  <img width="250" src="https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/d1a65e9e-8fc6-4f8a-9594-736de907d223"> |


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #132
