### PR TITLE
[Fix] #139 - 홈 상세보기뷰 데이터에 따른 UI 수정

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionDetailCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionDetailCollectionViewCell.swift
@@ -119,7 +119,7 @@ extension MissionDetailCollectionViewCell {
         missionTagLabel.text = model.situation
         missionLabel.text = model.title
         accumulateLabel.text = "\(model.count)회\n달성"
-        if model.actions.isEmpty {
+        if model.actions.isEmpty || model.actions.contains(where: { $0.name.isEmpty }) {
             action.titleLabel.isHidden = true
             action.emptyIcon.isHidden = false
         } else {


### PR DESCRIPTION
## 🫧 작업한 내용

- 행동 nil인 경우 empty 뷰가 뜨지 않아  코드를 수정했습니다. 
## 🔫 PR Point



## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   GIF           |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/7b47befa-a534-4ec5-ae46-014c887967c8" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #139
