### PR TITLE
[Fix] #141 - 홈 상세보기, 다른 날짜 추가 UI 수정

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionDetailCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionDetailCollectionViewCell.swift
@@ -23,7 +23,6 @@ final class MissionDetailCollectionViewCell: UICollectionViewCell {
     private let accumulateView = UIView()
     private let accumulateSubView = UIView()
     private let accumulateLabel = UILabel()
-    
     private let verticalStackView = UIStackView()
     private let action = DetailStackView(tag: I18N.detailAction, isTop: true, empty: .actionEmpty)
     private let goal = DetailStackView(tag: I18N.detailGoal, isTop: false, empty: .goalEmpty)
@@ -54,9 +53,11 @@ extension MissionDetailCollectionViewCell {
             $0.font = .Pretendard(.medium, size: 14)
             $0.textColor = .gray1
         }
+        
         missionLabel.do {
             $0.font = .Pretendard(.semiBold, size: 20)
             $0.textColor = .gray2
+            $0.numberOfLines = 0
         }
         
         accumulateView.do {
@@ -64,17 +65,20 @@ extension MissionDetailCollectionViewCell {
             $0.layer.masksToBounds = true
             $0.layer.cornerRadius = 34
         }
+        
         accumulateSubView.do {
             $0.backgroundColor = .green2
             $0.layer.masksToBounds = true
             $0.layer.cornerRadius = 28
         }
+        
         accumulateLabel.do {
             $0.textAlignment = .center
             $0.textColor = .white
             $0.font = .Pretendard(.semiBold, size: 14)
             $0.numberOfLines = 2
         }
+        
         verticalStackView.do {
             $0.addArrangedSubviews(action, goal)
             $0.axis = .vertical
@@ -84,16 +88,12 @@ extension MissionDetailCollectionViewCell {
     }
     
     private func setLayout() {
-        contentView.addSubviews(missionTagLabel, missionLabel, accumulateView, verticalStackView)
+        contentView.addSubviews(missionTagLabel, accumulateView, missionLabel, verticalStackView)
         accumulateView.addSubviews(accumulateSubView, accumulateLabel)
         
         missionTagLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(30)
             $0.leading.equalToSuperview().offset(29)
-        }
-        missionLabel.snp.makeConstraints {
-            $0.top.equalTo(missionTagLabel.snp.bottom).offset(10)
-            $0.leading.equalTo(missionTagLabel.snp.leading)
         }
         
         accumulateView.snp.makeConstraints {
@@ -101,13 +101,22 @@ extension MissionDetailCollectionViewCell {
             $0.trailing.equalToSuperview().inset(19)
             $0.width.height.equalTo(68)
         }
+        
         accumulateSubView.snp.makeConstraints {
             $0.center.centerY.equalToSuperview()
             $0.width.height.equalTo(56)
         }
+        
+        missionLabel.snp.makeConstraints {
+            $0.top.equalTo(missionTagLabel.snp.bottom).offset(10)
+            $0.leading.equalTo(missionTagLabel.snp.leading)
+            $0.trailing.equalTo(accumulateView.snp.leading).offset(-30)
+        }
+        
         accumulateLabel.snp.makeConstraints {
             $0.centerX.centerY.equalToSuperview()
         }
+        
         verticalStackView.snp.makeConstraints {
             $0.top.equalTo(missionLabel.snp.bottom).offset(56)
             $0.directionalHorizontalEdges.equalToSuperview().inset(29)
@@ -118,7 +127,9 @@ extension MissionDetailCollectionViewCell {
     func configure(model: MissionDetailResponseDTO) {
         missionTagLabel.text = model.situation
         missionLabel.text = model.title
+        missionLabel.setLineSpacing(lineSpacing: 6.0)
         accumulateLabel.text = "\(model.count)회\n달성"
+        
         if model.actions.isEmpty || model.actions.contains(where: { $0.name.isEmpty }) {
             action.titleLabel.isHidden = true
             action.emptyIcon.isHidden = false
@@ -130,6 +141,7 @@ extension MissionDetailCollectionViewCell {
             action.verticalStackView.removeArrangedSubview(action.emptyIcon)
             action.emptyIcon.removeFromSuperview()
         }
+        
         if model.goal.isEmpty {
             goal.titleLabel.isHidden = true
             goal.emptyIcon.isHidden = false

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/DetailCalendarViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/DetailCalendarViewController.swift
@@ -190,16 +190,19 @@ extension DetailCalendarViewController {
     private func requestAddAnotherDay(id: Int, dates: [String]) {
         HomeAPI.shared.postAnotherDay(id: id, dates: dates) { response in
             guard response != nil else { return }
-            self.setUI()
-            self.dismiss(animated: true)
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy.MM.dd"
-            if let earliestDate = dateFormatter.date(from: self.anotherDate.min() ?? "") {
-                let earliestDateString = dateFormatter.string(from: earliestDate)
-                print("The earliest date is \(earliestDateString)")
-                self.movedateClosure?(earliestDateString)
-            } else {
-                print("Invalid date strings")
+            guard let statusCode = response?.status else { return }
+            switch statusCode {
+            case 200..<204:
+                self.setUI()
+                self.dismiss(animated: true)
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy.MM.dd"
+                if let earliestDate = dateFormatter.date(from: self.anotherDate.min() ?? "") {
+                    let earliestDateString = dateFormatter.string(from: earliestDate)
+                    self.movedateClosure?(earliestDateString)
+                }
+            default:
+                self.showToast(message: self.htmlToString(response?.message ?? "")?.string ?? "", controller: self)
             }
         }
     }


### PR DESCRIPTION
## 🫧 작업한 내용

- 홈 상세보기 뷰 낫투두 글씨와 달성 횟수 사이 여백 주었습니다.
- 다른 날짜 추가하기뷰에서 3개 이상 낫투두가 등록되었을 때 토스트 메시지가 나타나도록 연결해두었습니다.
## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   홈 상세보기뷰         |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/add4d3f7-3cbf-4f9e-9a82-9189262482de" width ="250">|
|   홈 다른날짜추가뷰        |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/b5edb421-31c1-4380-8450-3c5e80c68327" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #141
