### PR TITLE
[Feat] #143 - 앰플리튜드 설치 및 이벤트 넣기 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_Store
 .AppleDouble
 .LSOverride
-
+API_KEY.plist
 # Icon must end with two \r
 Icon
 

--- a/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
+++ b/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		09022D4629C44BC300DE6E49 /* MissionCalendarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09022D4529C44BC300DE6E49 /* MissionCalendarCell.swift */; };
+		0921611B2A5727EF0019CC8C /* AnalyticsEventProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0921611A2A5727EF0019CC8C /* AnalyticsEventProtocol.swift */; };
+		0921611D2A57D0920019CC8C /* AmplitudeAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0921611C2A57D0920019CC8C /* AmplitudeAnalyticsService.swift */; };
+		0921611F2A57D7BF0019CC8C /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0921611E2A57D7BF0019CC8C /* AnalyticsEvent.swift */; };
+		092161212A58296D0019CC8C /* API_KEY.plist in Resources */ = {isa = PBXBuildFile; fileRef = 092161202A58296D0019CC8C /* API_KEY.plist */; };
 		092C09B52A484DD900E9B06B /* HomeDeleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092C09B42A484DD900E9B06B /* HomeDeleteViewController.swift */; };
 		092C09B72A48596500E9B06B /* DeleteModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092C09B62A48596500E9B06B /* DeleteModalView.swift */; };
 		092E04B129BD9C86008A5892 /* MissionDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092E04B029BD9C86008A5892 /* MissionDetailCollectionViewCell.swift */; };
@@ -18,6 +22,8 @@
 		093DB03B2A15F6E700ECA5F6 /* AchieveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093DB03A2A15F6E700ECA5F6 /* AchieveService.swift */; };
 		093DB03D2A15FC7800ECA5F6 /* AchieveCalendarResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093DB03C2A15FC7800ECA5F6 /* AchieveCalendarResponseDTO.swift */; };
 		093DB03F2A15FCC100ECA5F6 /* MissionDetailResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 093DB03E2A15FCC100ECA5F6 /* MissionDetailResponseDTO.swift */; };
+		0943A9F52A531D0000614761 /* Amplitude in Frameworks */ = {isa = PBXBuildFile; productRef = 0943A9F42A531D0000614761 /* Amplitude */; };
+		0943A9F92A53239200614761 /* Bundle+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0943A9F82A53239200614761 /* Bundle+.swift */; };
 		09582B4829BDA7F600EF3207 /* DetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09582B4729BDA7F600EF3207 /* DetailStackView.swift */; };
 		09582B4B29BDE37C00EF3207 /* DetailFooterReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09582B4A29BDE37C00EF3207 /* DetailFooterReusableView.swift */; };
 		09582B4D29BE277800EF3207 /* DetailHeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09582B4C29BE277800EF3207 /* DetailHeaderReusableView.swift */; };
@@ -160,6 +166,10 @@
 
 /* Begin PBXFileReference section */
 		09022D4529C44BC300DE6E49 /* MissionCalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionCalendarCell.swift; sourceTree = "<group>"; };
+		0921611A2A5727EF0019CC8C /* AnalyticsEventProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEventProtocol.swift; sourceTree = "<group>"; };
+		0921611C2A57D0920019CC8C /* AmplitudeAnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmplitudeAnalyticsService.swift; sourceTree = "<group>"; };
+		0921611E2A57D7BF0019CC8C /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
+		092161202A58296D0019CC8C /* API_KEY.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = API_KEY.plist; sourceTree = "<group>"; };
 		092C09B42A484DD900E9B06B /* HomeDeleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDeleteViewController.swift; sourceTree = "<group>"; };
 		092C09B62A48596500E9B06B /* DeleteModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteModalView.swift; sourceTree = "<group>"; };
 		092E04B029BD9C86008A5892 /* MissionDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionDetailCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -170,6 +180,7 @@
 		093DB03A2A15F6E700ECA5F6 /* AchieveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchieveService.swift; sourceTree = "<group>"; };
 		093DB03C2A15FC7800ECA5F6 /* AchieveCalendarResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchieveCalendarResponseDTO.swift; sourceTree = "<group>"; };
 		093DB03E2A15FCC100ECA5F6 /* MissionDetailResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionDetailResponseDTO.swift; sourceTree = "<group>"; };
+		0943A9F82A53239200614761 /* Bundle+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+.swift"; sourceTree = "<group>"; };
 		09582B4729BDA7F600EF3207 /* DetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailStackView.swift; sourceTree = "<group>"; };
 		09582B4A29BDE37C00EF3207 /* DetailFooterReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailFooterReusableView.swift; sourceTree = "<group>"; };
 		09582B4C29BE277800EF3207 /* DetailHeaderReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailHeaderReusableView.swift; sourceTree = "<group>"; };
@@ -318,6 +329,7 @@
 				6C44128129A35A1000313C3F /* KakaoSDKUser in Frameworks */,
 				6C44127D29A35A1000313C3F /* KakaoSDKTalk in Frameworks */,
 				6C44127529A35A1000313C3F /* KakaoSDKCommon in Frameworks */,
+				0943A9F52A531D0000614761 /* Amplitude in Frameworks */,
 				6C44127329A35A1000313C3F /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -349,6 +361,15 @@
 				09582B4729BDA7F600EF3207 /* DetailStackView.swift */,
 			);
 			path = StackView;
+			sourceTree = "<group>";
+		};
+		092161192A5727DB0019CC8C /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				0921611A2A5727EF0019CC8C /* AnalyticsEventProtocol.swift */,
+				0921611C2A57D0920019CC8C /* AmplitudeAnalyticsService.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		093DB02B2A14687300ECA5F6 /* API */ = {
@@ -391,6 +412,7 @@
 			isa = PBXGroup;
 			children = (
 				093DB0362A146BF900ECA5F6 /* MyInfoURL.swift */,
+				0921611E2A57D7BF0019CC8C /* AnalyticsEvent.swift */,
 				0960C0D32A38BC6500A3D8DB /* KeychainUtil.swift */,
 				0960C0D52A38BC8100A3D8DB /* DefaultKeys.swift */,
 			);
@@ -601,6 +623,7 @@
 		3B027A8C299C337900BEB65C /* Global */ = {
 			isa = PBXGroup;
 			children = (
+				092161192A5727DB0019CC8C /* Protocol */,
 				093DB0352A146BE800ECA5F6 /* Enum */,
 				6CF4706829A71D67008D145C /* Literals */,
 				3B027A8E299C339B00BEB65C /* Extensions */,
@@ -625,6 +648,7 @@
 				6CA208282A191185001C4247 /* UIImageView+.swift */,
 				097568352A2FEF3F0001EC46 /* String+.swift */,
 				3B11740C2A4B574B0033DDF3 /* CALayer+.swift */,
+				0943A9F82A53239200614761 /* Bundle+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -729,6 +753,7 @@
 		3B027AA6299C359900BEB65C /* Resource */ = {
 			isa = PBXGroup;
 			children = (
+				092161202A58296D0019CC8C /* API_KEY.plist */,
 				3B027A85299C31B600BEB65C /* Info.plist */,
 				3B027AAA299C35D000BEB65C /* Assets */,
 				3B027AA9299C35CB00BEB65C /* Colors */,
@@ -1126,6 +1151,7 @@
 				099FC97A29B305F0005B37E6 /* FSCalendar */,
 				6CA2082B2A19122A001C4247 /* Kingfisher */,
 				6C9628A62A22208F003ADE25 /* Lottie */,
+				0943A9F42A531D0000614761 /* Amplitude */,
 			);
 			productName = "iOS-NOTTODO";
 			productReference = 3B027A74299C31B500BEB65C /* iOS-NOTTODO.app */;
@@ -1163,6 +1189,7 @@
 				099FC97929B305F0005B37E6 /* XCRemoteSwiftPackageReference "FSCalendar" */,
 				6CA2082A2A19122A001C4247 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				6C9628A52A22208F003ADE25 /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				0943A9F32A531D0000614761 /* XCRemoteSwiftPackageReference "Amplitude-iOS" */,
 			);
 			productRefGroup = 3B027A75299C31B500BEB65C /* Products */;
 			projectDirPath = "";
@@ -1181,6 +1208,7 @@
 				3B027AAC299C35E500BEB65C /* Colors.xcassets in Resources */,
 				3B4E12FA2A27C4DD001D1EC1 /* Pretendard-Bold.otf in Resources */,
 				3B146D9C299D07D500B17B62 /* Pretendard-Regular.otf in Resources */,
+				092161212A58296D0019CC8C /* API_KEY.plist in Resources */,
 				3B146D9E299D081400B17B62 /* Pretendard-SemiBold.otf in Resources */,
 				3B027A84299C31B600BEB65C /* LaunchScreen.storyboard in Resources */,
 				6CC54C1A2A28C3AE00AAD76D /* value.json in Resources */,
@@ -1243,7 +1271,9 @@
 				098BFD5929B7999E008E80F9 /* MyProfileCollectionViewCell.swift in Sources */,
 				3B5F8F7A29BF8E8D0063A7F8 /* AddMissionProtocol.swift in Sources */,
 				09F6718C29CB4AB700708725 /* SubOnboardingCollectionViewCell.swift in Sources */,
+				0921611D2A57D0920019CC8C /* AmplitudeAnalyticsService.swift in Sources */,
 				3B027A96299C340C00BEB65C /* UIImage+.swift in Sources */,
+				0921611F2A57D7BF0019CC8C /* AnalyticsEvent.swift in Sources */,
 				098BFD5B29B79B6A008E80F9 /* MyInfoModel.swift in Sources */,
 				09DCCD1F2A18ED76003DCF8A /* DailyMissionResponseDTO.swift in Sources */,
 				6CF4707A29A7AAFF008D145C /* PaddingLabel.swift in Sources */,
@@ -1324,6 +1354,7 @@
 				6C16016429C5E37D005AE3F5 /* MyInfoAccountStackView.swift in Sources */,
 				09F6718229CAD86100708725 /* OnboardingCollectionViewCell.swift in Sources */,
 				6CF4707029A73A15008D145C /* RecommendActionViewController.swift in Sources */,
+				0943A9F92A53239200614761 /* Bundle+.swift in Sources */,
 				0982DE5429ADCCE000D933D2 /* HomeEmptyCollectionViewCell.swift in Sources */,
 				3BEEBE972A4B048A0081C936 /* NottodoToastView.swift in Sources */,
 				3B027AA2299C355800BEB65C /* AchievementViewController.swift in Sources */,
@@ -1344,6 +1375,7 @@
 				3B4E12F62A27C0BE001D1EC1 /* QuitModalView.swift in Sources */,
 				6CA208232A18FE78001C4247 /* RecommendAPI.swift in Sources */,
 				6CA208342A1956ED001C4247 /* AuthService.swift in Sources */,
+				0921611B2A5727EF0019CC8C /* AnalyticsEventProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1565,6 +1597,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		0943A9F32A531D0000614761 /* XCRemoteSwiftPackageReference "Amplitude-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/amplitude/Amplitude-iOS";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		099FC97929B305F0005B37E6 /* XCRemoteSwiftPackageReference "FSCalendar" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/WenchaoD/FSCalendar.git";
@@ -1624,6 +1664,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0943A9F42A531D0000614761 /* Amplitude */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0943A9F32A531D0000614761 /* XCRemoteSwiftPackageReference "Amplitude-iOS" */;
+			productName = Amplitude;
+		};
 		099FC97A29B305F0005B37E6 /* FSCalendar */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 099FC97929B305F0005B37E6 /* XCRemoteSwiftPackageReference "FSCalendar" */;

--- a/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
@@ -12,6 +12,7 @@ import KakaoSDKAuth
 import KakaoSDKUser
 
 import AuthenticationServices
+import Amplitude
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -19,9 +20,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         
-        KakaoSDK.initSDK(appKey: "f06c671df540ff4a8f8275f453368748")
+        Amplitude.instance().initializeApiKey(Bundle.main.amplitudeAPIKey)
+        
+        KakaoSDK.initSDK(appKey: Bundle.main.kakaoAPIKey)
         
         if KeychainUtil.getAccessToken() != "" {
             // self.skipAuthView()

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/AnalyticsEvent.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/AnalyticsEvent.swift
@@ -1,0 +1,209 @@
+//
+//  AnalyticsEvent.swift
+//  iOS-NOTTODO
+//
+//  Created by JEONGEUN KIM on 2023/07/07.
+//
+
+import Foundation
+
+enum AnalyticsEvent {
+    
+    enum Onboarding: String, AnalyticsEventProtocol {
+        
+        case viewOnboarding2 = "view_onboarding_2"
+        case viewOnboarding3 = "view_onboarding_3"
+        case viewOnboarding4 = "view_onboarding_4"
+        case viewOnboarding5 = "view_onboarding_5"
+        
+        var name: String {
+            return self.rawValue
+        }
+    }
+    
+    enum OnboardingClick: AnalyticsEventProtocol {
+        case clickOnboardingStart
+        case clickOnboardingNext2(select: String)
+        case clickOnboardingNext3(select: [String])
+        case clickOnboardingNext4
+        case clickOnboardingNext5
+                
+        var name: String {
+            switch self {
+            case .clickOnboardingStart: return "click_onboarding_start"
+            case .clickOnboardingNext2: return "click_onboarding_next_2"
+            case .clickOnboardingNext3: return "click_onboarding_next_3"
+            case .clickOnboardingNext4: return "click_onboarding_next_4"
+            case .clickOnboardingNext5: return "click_onboarding_next_5"
+                
+            }
+        }
+        
+        var parameters: [String: Any]? {
+            switch self {
+            case .clickOnboardingStart: return nil
+            case .clickOnboardingNext2(select: let select): return ["onboard_select": select]
+            case .clickOnboardingNext3(select: let select): return ["onboard_select": select]
+            case .clickOnboardingNext4: return nil
+            case .clickOnboardingNext5: return nil
+            }
+        }
+    }
+    
+    enum Login: AnalyticsEventProtocol {
+        
+        case viewSignIn
+        case clickSignIn(provider: String)
+        case completeSignIn(provider: String)
+        
+        var name: String {
+            switch self {
+            case .viewSignIn: return "view_signin"
+            case .clickSignIn: return  "click_signin"
+            case .completeSignIn: return "complete_signin"
+            }
+        }
+        
+        var parameters: [String: Any]? {
+            switch self {
+            case .viewSignIn: return nil
+            case .clickSignIn(provider: let provider ): return ["provider": provider]
+            case .completeSignIn(provider: let provider): return ["provider": provider]
+            }
+        }
+    }
+    
+    enum Home: AnalyticsEventProtocol {
+        case viewHome
+        case clickReturnToday
+        case clickWeeklyDate(date: String)
+        case completeCheckMission(title: String, situation: String)
+        case completeUncheckMission(title: String, situation: String)
+        
+        var name: String {
+            switch self {
+            case .viewHome: return "view_home"
+            case .clickReturnToday: return "click_return_today"
+            case .clickWeeklyDate: return "click_weekly_date"
+            case .completeCheckMission: return "complete_check_mission"
+            case .completeUncheckMission: return "complete_uncheck_mission"
+            }
+        }
+        
+        var parameters: [String: Any]? {
+            switch self {
+            case .viewHome: return nil
+            case .clickReturnToday: return nil
+            case .clickWeeklyDate(date: let date): return ["date": date]
+            case .completeCheckMission(title: let title, situation: let situation): return ["title": title, "situation": situation]
+            case .completeUncheckMission(title: let title, situation: let situation): return ["title": title, "situation": situation]
+            }
+        }
+    }
+    
+    enum Detail: AnalyticsEventProtocol {
+        
+        case appearDetailMission(title: String, situation: String, goal: String, action: String)
+        case closeDetailMission
+        case clickDeleteMission(title: String, situation: String, goal: String, action: String)
+        case completeDeleteMission(title: String, situation: String, goal: String, action: String)
+        case clickEditMission
+        
+        var name: String {
+            switch self {
+            case .appearDetailMission: return "appear_detail_mission"
+            case .closeDetailMission: return "close_detail_mission"
+            case .clickDeleteMission: return "click_delete_mission"
+            case .completeDeleteMission: return "complete_delete_mission"
+            case .clickEditMission: return "click_edit_mission"
+            }
+        }
+        
+        var parameters: [String: Any]? {
+            switch self {
+            case .appearDetailMission(title: let title, situation: let situation, goal: let goal, action: let action): return ["title": title, "situation": situation, "goal": goal, "action": action]
+            case .closeDetailMission: return nil
+            case .clickDeleteMission(title: let title, situation: let situation, goal: let goal, action: let action): return ["title": title, "situation": situation, "goal": goal, "action": action]
+            case .completeDeleteMission(title: let title, situation: let situation, goal: let goal, action: let action): return ["title": title, "situation": situation, "goal": goal, "action": action]
+            case .clickEditMission: return nil
+            }
+        }
+    }
+    
+    enum SelectDate: AnalyticsEventProtocol {
+        
+        case appearAnotherDayModal
+        case closeAnotherDayModal
+        case completeAddMissionAnotherDay(title: String, situation: String, goal: String, action: String, date: [String])
+        
+        var name: String {
+            switch self {
+            case .appearAnotherDayModal: return "appear_another_day_modal"
+            case .closeAnotherDayModal: return "close_another_day_modal"
+            case .completeAddMissionAnotherDay: return "complete_add_mission_another_day"
+            }
+        }
+        
+        var parameters: [String: Any]? {
+            switch self {
+            case .appearAnotherDayModal: return nil
+            case .closeAnotherDayModal: return nil
+            case .completeAddMissionAnotherDay(title: let title, situation: let situation, goal: let goal, action: let action, date: let date): return ["title": title, "situation": situation, "goal": goal, "action": action, "date": date]
+            }
+        }
+    }
+    
+    enum Achieve: AnalyticsEventProtocol {
+        
+        case appearDailyMissionModal(total: Int)
+        case closeDailyMissionModal
+        case viewAccomplish
+        
+        var name: String {
+            switch self {
+            case .appearDailyMissionModal: return "appear_daily_mission_modal"
+            case .closeDailyMissionModal: return "close_daily_mission_modal"
+            case .viewAccomplish: return "view_accomplish"
+            }
+        }
+        
+        var parameters: [String: Any]? {
+            switch self {
+            case .appearDailyMissionModal(total: let total): return ["total_add_mission": total]
+            case .closeDailyMissionModal: return nil
+            case .viewAccomplish: return nil
+            }
+        }
+    }
+    
+    enum MyInfo: String, AnalyticsEventProtocol {
+        
+        case viewMyInfo = "view_my_info"
+        case clickMyInfo = "click_my_info"
+        case clickGuide = "click_guide"
+        case clickFaq = "click_faq"
+        case clickNotice = "click_notice"
+        case clickQuestion = "click_question"
+        case clickTerms = "click_terms"
+        case clickOpenSource = "click_opensource"
+        
+        var name: String {
+            return self.rawValue
+        }
+    }
+    
+    enum AccountInfo: String, AnalyticsEventProtocol {
+        
+        case viewAccountInfo = "view_account_info"
+        case appearLogoutModal = "appear_logout_modal"
+        case completeLogout = "complete_logout"
+        case completePushOn = "complete_push_on"
+        case completePushOff = "complete_push_off"
+        case appearWithdrawalModal = "appear_withdrawal_modal"
+        case completeWithdrawal = "complete_withdrawal"
+        
+        var name: String {
+            return self.rawValue
+        }
+    }
+}

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Extensions/Bundle+.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Extensions/Bundle+.swift
@@ -1,0 +1,35 @@
+//
+//  Bundle+.swift
+//  iOS-NOTTODO
+//
+//  Created by JEONGEUN KIM on 2023/07/04.
+//
+//
+import Foundation
+
+extension Bundle {
+    
+    var amplitudeAPIKey: String {
+        guard let filePath = Bundle.main.path(forResource: "API_KEY", ofType: "plist") else {
+            fatalError("Couldn't find file 'AMPLITUDE_API_KEY.plist'.")
+        }
+        let plist = NSDictionary(contentsOfFile: filePath)
+        
+        guard let value = plist?.object(forKey: "AMPLITUDE_API_KEY") as? String else {
+            fatalError("Couldn't find key 'AMPLITUDE_API_KEY' in 'API_KEY.plist'.")
+        }
+        return value
+    }
+    
+    var kakaoAPIKey: String {
+        guard let filePath = Bundle.main.path(forResource: "API_KEY", ofType: "plist") else {
+            fatalError("Couldn't find file 'AMPLITUDE_API_KEY.plist'.")
+        }
+        let plist = NSDictionary(contentsOfFile: filePath)
+        
+        guard let value = plist?.object(forKey: "KAKAO_API_KEY") as? String else {
+            fatalError("Couldn't find key 'AMPLITUDE_API_KEY' in 'API_KEY.plist'.")
+        }
+        return value
+    }
+}

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Protocol/AmplitudeAnalyticsService.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Protocol/AmplitudeAnalyticsService.swift
@@ -1,0 +1,24 @@
+//
+//  AmplitudeAnalyticsService.swift
+//  iOS-NOTTODO
+//
+//  Created by JEONGEUN KIM on 2023/07/07.
+//
+
+import UIKit
+
+import Amplitude
+
+class AmplitudeAnalyticsService: AnalyticsServiceProtocol {
+    static let shared: AmplitudeAnalyticsService = AmplitudeAnalyticsService()
+  
+    init() {}
+    
+    func send(event: AnalyticsEventProtocol) {
+        if let parameters = event.parameters {
+            Amplitude.instance().logEvent(event.name, withEventProperties: parameters)
+        } else {
+            Amplitude.instance().logEvent(event.name)
+        }
+    }
+}

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Protocol/AnalyticsEventProtocol.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Protocol/AnalyticsEventProtocol.swift
@@ -1,0 +1,27 @@
+//
+//  amplitudeProtocol.swift
+//  iOS-NOTTODO
+//
+//  Created by JEONGEUN KIM on 2023/07/07.
+//
+
+import UIKit
+
+import Amplitude
+
+public protocol AnalyticsEventProtocol {
+
+    var name: String { get }
+  
+    var parameters: [String: Any]? { get }
+}
+
+extension AnalyticsEventProtocol {
+
+    var parameters: [String: Any]? { return nil }
+}
+
+public protocol AnalyticsServiceProtocol {
+
+    func send(event: AnalyticsEventProtocol)
+}

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Achievement/ViewControllers/AchievementViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Achievement/ViewControllers/AchievementViewController.swift
@@ -36,7 +36,8 @@ final class AchievementViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Achieve.viewAccomplish)
+        
         if let today = monthCalendar.calendar.today {
             monthCalendar.yearMonthLabel.text = Utils.dateFormatterString(format: I18N.yearMonthTitle, date: today)
             monthCalendar.calendar.currentPage = today

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Achievement/ViewControllers/DetailAchievementViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Achievement/ViewControllers/DetailAchievementViewController.swift
@@ -35,6 +35,7 @@ class DetailAchievementViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Achieve.appearDailyMissionModal(total: self.missionList.count))
         if let selectedDate = selectedDate {
             requestDetailAPI(date: Utils.dateFormatterString(format: "YYYY-MM-dd", date: selectedDate))
         }
@@ -54,6 +55,7 @@ class DetailAchievementViewController: UIViewController {
         let location = touch.location(in: self.view)
         
         if !backGroundView.frame.contains(location) {
+            AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Achieve.closeDailyMissionModal)
             self.dismiss(animated: true)
         }
     }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
@@ -7,10 +7,11 @@
 
 import UIKit
 
-import AuthenticationServices
-import SafariServices
 import SnapKit
 import Then
+
+import AuthenticationServices
+import SafariServices
 import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
@@ -36,6 +37,7 @@ class AuthViewController: UIViewController {
    
     override func viewDidLoad() {
         super.viewDidLoad()
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Login.viewSignIn)
         setUI()
         setLayout()
     }
@@ -160,6 +162,8 @@ extension AuthViewController {
     }
     
     @objc func kakaoLoginButtonClicked() {
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Login.clickSignIn(provider: "kakao"))
+
         if UserApi.isKakaoTalkLoginAvailable() {
             kakaoLoginWithApp()
         } else {
@@ -169,6 +173,8 @@ extension AuthViewController {
     
     @objc
     func appleLoginButtonClicked() {
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Login.clickSignIn(provider: "apple"))
+
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName, .email]
@@ -228,9 +234,12 @@ extension AuthViewController {
                     guard self != nil else { return }
                     guard result != nil else { return }
                     
+                    AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Login.completeSignIn(provider: "kakao"))
+                    
                     guard let accessToken = result?.data?.accessToken else { return }
                     KeychainUtil.setAccessToken(accessToken)
                     self?.presentToHomeViewController()
+                    
                 }
             }
         }
@@ -280,6 +289,8 @@ extension AuthViewController: ASAuthorizationControllerDelegate, ASAuthorization
             AuthAPI.shared.postAppleAuth(social: LoginType.Apple.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken, name: KeychainUtil.getAppleUsername()) { [weak self] result in
                 guard self != nil else { return }
                 guard result != nil else { return }
+                
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Login.completeSignIn(provider: "apple"))
                 
                 guard let accessToken = result?.data?.accessToken else { return }
                 KeychainUtil.setAccessToken(accessToken)

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Modal/NottodoModalViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Modal/NottodoModalViewController.swift
@@ -39,6 +39,7 @@ final class NottodoModalViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.AccountInfo.appearWithdrawalModal)
         setUI()
         setLayout()
         setDelegate()
@@ -116,6 +117,7 @@ extension NottodoModalViewController {
                 UserDefaults.standard.removeObject(forKey: key.description)
             }
             UserDefaults.standard.removeObject(forKey: DefaultKeys.accessToken)
+            AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.AccountInfo.completeWithdrawal)
         }
     }
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/DetailCalendarViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/DetailCalendarViewController.swift
@@ -18,6 +18,7 @@ final class DetailCalendarViewController: UIViewController {
     var anotherDate: [String] = []
     var invalidDate: [String] = []
     var dataSource: [String: Float] = [:]
+    var detailModel: [MissionDetailResponseDTO] = []
     var userId: Int?
     var count: Int?
     var movedateClosure: ((_ date: String) -> Void)?
@@ -34,6 +35,7 @@ final class DetailCalendarViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.SelectDate.appearAnotherDayModal)
         if let id = self.userId {
             requestParticualrDatesAPI(id: id)
         }
@@ -121,6 +123,7 @@ extension DetailCalendarViewController {
     func completeBtnTapped(sender: UIButton) {
         if let id = self.userId {
             requestAddAnotherDay(id: id, dates: anotherDate)
+            AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.SelectDate.completeAddMissionAnotherDay(title: self.detailModel[0].title, situation: self.detailModel[0].situation, goal: self.detailModel[0].goal, action: self.detailModel[0].actions[0].name, date: anotherDate))
         }
     }
 }
@@ -195,6 +198,7 @@ extension DetailCalendarViewController {
             case 200..<204:
                 self.setUI()
                 self.dismiss(animated: true)
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.SelectDate.closeAnotherDayModal)
                 let dateFormatter = DateFormatter()
                 dateFormatter.dateFormat = "yyyy.MM.dd"
                 if let earliestDate = dateFormatter.date(from: self.anotherDate.min() ?? "") {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/MissionDetailViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/MissionDetailViewController.swift
@@ -36,6 +36,7 @@ final class MissionDetailViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.closeDetailMission)
         guard let id = self.userId else { return }
         requestDailyMissionAPI(id: id)
     }
@@ -123,6 +124,8 @@ extension MissionDetailViewController {
                     self.dismiss(animated: true)
                 }
                 header.editClosure = {
+                    AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.clickEditMission)
+                    
                     let updateMissionViewController = AddMissionViewController()
                     guard let rootViewController = self.presentingViewController as? UINavigationController else { return }
                     updateMissionViewController.setMissionId(self.userId ?? 0)
@@ -136,6 +139,7 @@ extension MissionDetailViewController {
                 guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: DetailFooterReusableView.identifier, for: indexPath) as? DetailFooterReusableView else { return UICollectionReusableView() }
                 footer.footerClosure = {
                     let modalViewController = DetailCalendarViewController()
+                    modalViewController.detailModel = self.detailModel
                     modalViewController.modalPresentationStyle = .overFullScreen
                     modalViewController.modalTransitionStyle = .crossDissolve
                     guard let id = self.userId else {return}
@@ -164,11 +168,13 @@ extension MissionDetailViewController {
     
     @objc
     func deleteBtnTapped() {
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.clickDeleteMission(title: self.detailModel[0].title, situation: self.detailModel[0].situation, goal: self.detailModel[0].goal, action: self.detailModel[0].actions[0].name))
         let modalViewController = HomeDeleteViewController()
         modalViewController.modalPresentationStyle = .overFullScreen
         modalViewController.modalTransitionStyle = .crossDissolve
         modalViewController.deleteClosure = {
             guard let id = self.userId else { return }
+            
             self.requestDeleteMission(id: id)
         }
         present(modalViewController, animated: false)
@@ -205,7 +211,9 @@ extension MissionDetailViewController {
                 if self?.detailModel[index].id == id {
                     self?.deleteClosure?()
                     self?.reloadData()
+                    AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.completeDeleteMission(title: (self?.detailModel[index].title)!, situation: (self?.detailModel[index].situation)!, goal: self?.detailModel[index].goal ?? "", action: self?.detailModel[index].actions[index].name ?? ""))
                     self?.dismiss(animated: true)
+                    AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.closeDetailMission)
                 } else {}
             }
         }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/MyInfo/Viewcontrollers/MyInfoViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/MyInfo/Viewcontrollers/MyInfoViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 
 import Then
 import SnapKit
-import MessageUI
 
 final class MyInfoViewController: UIViewController {
     
@@ -35,6 +34,7 @@ final class MyInfoViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.MyInfo.viewMyInfo)
         setUI()
         register()
         setLayout()
@@ -137,24 +137,31 @@ extension MyInfoViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         switch indexPath.section {
         case 0:
+            AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.MyInfo.clickMyInfo)
             let nextViewController = MyInfoAccountViewController()
             navigationController?.pushViewController(nextViewController, animated: true)
         case 1:
             switch indexPath.item {
             case 0:
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.MyInfo.clickGuide)
                 Utils.myInfoUrl(vc: self, url: MyInfoURL.guid.url)
             default:
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.MyInfo.clickFaq)
                 Utils.myInfoUrl(vc: self, url: MyInfoURL.quesition.url)
             }
         case 2:
             switch indexPath.item {
             case 0:
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.MyInfo.clickNotice)
                 Utils.myInfoUrl(vc: self, url: MyInfoURL.notice.url)
             case 1:
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.MyInfo.clickQuestion)
                 Utils.myInfoUrl(vc: self, url: MyInfoURL.contact.url)
             case 2:
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.MyInfo.clickTerms)
                 Utils.myInfoUrl(vc: self, url: MyInfoURL.service.url)
             default:
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.MyInfo.clickOpenSource)
                 Utils.myInfoUrl(vc: self, url: MyInfoURL.opensource.url)
             }
         default:

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/MyInfoAccount/ViewControllers/MyInfoAccountStackView.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/MyInfoAccount/ViewControllers/MyInfoAccountStackView.swift
@@ -107,5 +107,7 @@ extension MyInfoAccountStackView {
     @objc func switchTapped(_ sender: Any) {
         isTapped.toggle()
         switchClosure?(isTapped)
+        
+        AmplitudeAnalyticsService.shared.send(event: isTapped ? AnalyticsEvent.AccountInfo.completePushOn :  AnalyticsEvent.AccountInfo.completePushOff)
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/MyInfoAccount/ViewControllers/MyInfoAccountViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/MyInfoAccount/ViewControllers/MyInfoAccountViewController.swift
@@ -30,6 +30,7 @@ class MyInfoAccountViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.AccountInfo.viewAccountInfo)
         setUI()
         setLayout()
         configure(model: MyInfoAccountModel(nickname: UserDefaults.standard.bool(forKey: DefaultKeys.isAppleLogin) ? KeychainUtil.getAppleUsername() : KeychainUtil.getKakaoUsername(), email: UserDefaults.standard.bool(forKey: DefaultKeys.isAppleLogin) ? KeychainUtil.getAppleEmail() : KeychainUtil.getKakaoEmail(), account: UserDefaults.standard.bool(forKey: DefaultKeys.isAppleLogin) ? "apple" : "kakao", notification: true))
@@ -160,6 +161,8 @@ private extension MyInfoAccountViewController {
     }
     @objc
     private func tappedLogout() {
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.AccountInfo.appearLogoutModal)
+        
         let logoutAlert = UIAlertController(title: I18N.logoutAlertTitle, message: I18N.logoutAlertmessage, preferredStyle: UIAlertController.Style.alert)
         let logoutAction = UIAlertAction(title: I18N.logout, style: UIAlertAction.Style.default, handler: {_ in
             self.logout()
@@ -180,7 +183,7 @@ extension MyInfoAccountViewController {
         AuthAPI.shared.deleteAuth { [weak self] _ in
             UserDefaults.standard.removeObject(forKey: DefaultKeys.accessToken)
             UserDefaults.standard.removeObject(forKey: DefaultKeys.socialToken)
-
+            AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.AccountInfo.completeLogout)
             let authViewController = AuthViewController()
             if let window = self?.view.window?.windowScene?.keyWindow {
                 let navigationController = UINavigationController(rootViewController: authViewController)

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/FifthOnboardingViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/FifthOnboardingViewController.swift
@@ -34,6 +34,7 @@ final class FifthOnboardingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Onboarding.viewOnboarding5)
         setUI()
         register()
         setLayout()
@@ -178,6 +179,8 @@ extension FifthOnboardingViewController {
 extension FifthOnboardingViewController {
     @objc
     private func ButtonTapped() {
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.OnboardingClick.clickOnboardingNext5)
+        
         if let window = view.window?.windowScene?.keyWindow {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 UIView.animate(withDuration: 0.01) {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/FourthOnboardingViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/FourthOnboardingViewController.swift
@@ -31,6 +31,7 @@ final class FourthOnboardingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Onboarding.viewOnboarding4)
         setUI()
         register()
         setLayout()
@@ -128,6 +129,8 @@ extension FourthOnboardingViewController {
 extension FourthOnboardingViewController {
     @objc
     private func ButtonTapped() {
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.OnboardingClick.clickOnboardingNext4)
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             UIView.animate(withDuration: 0.01) {
                 let nextViewController = FifthOnboardingViewController()

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/LogoOnboardingViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/LogoOnboardingViewController.swift
@@ -92,6 +92,8 @@ extension LogoOnboardingViewController {
 
     @objc
     private func buttonTapped() {
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.OnboardingClick.clickOnboardingStart)
+       
         let nextViewController = SecondOnboardingViewController()
         navigationController?.pushViewController(nextViewController, animated: false)
     }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/SecondOnboardingViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/SecondOnboardingViewController.swift
@@ -29,6 +29,7 @@ final class SecondOnboardingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Onboarding.viewOnboarding2)
         setUI()
         register()
         setLayout()
@@ -104,6 +105,8 @@ extension SecondOnboardingViewController {
 
 extension SecondOnboardingViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.OnboardingClick.clickOnboardingNext2(select: SecondOnboardingModel.titles[indexPath.row].title))
+
         let destinationViewController = ThirdOnboardingViewController()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             UIView.animate(withDuration: 0.01) {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/ThirdOnboardingViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Onboarding/ViewControllers/ThirdOnboardingViewController.swift
@@ -21,6 +21,7 @@ final class ThirdOnboardingViewController: UIViewController {
     private let onboardingModel: [ThirdOnboardingModel] = ThirdOnboardingModel.titles
     private var dataSource: UICollectionViewDiffableDataSource<Section, ThirdOnboardingModel>! = nil
     private lazy var safeArea = self.view.safeAreaLayoutGuide
+    private var selectList: [String] = []
 
     // MARK: - UI Components
     
@@ -32,6 +33,7 @@ final class ThirdOnboardingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Onboarding.viewOnboarding3)
         setUI()
         register()
         setLayout()
@@ -65,6 +67,14 @@ extension ThirdOnboardingViewController {
             $0.setTitleColor(isTapped ? .black :.gray4, for: .normal)
             $0.setTitle(I18N.thirdButton, for: .normal)
             $0.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        }
+    }
+    
+    private func updateButton(isTapped: Bool) {
+        nextButton.do {
+            $0.backgroundColor = isTapped ? .white : .gray2
+            $0.isUserInteractionEnabled = isTapped ? true : false
+            $0.setTitleColor(isTapped ? .black :.gray4, for: .normal)
         }
     }
     
@@ -127,6 +137,8 @@ extension ThirdOnboardingViewController {
     private func buttonTapped() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             UIView.animate(withDuration: 0.01) {
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.OnboardingClick.clickOnboardingNext3(select: self.selectList))
+
                 let nextViewController = FourthOnboardingViewController()
                 self.navigationController?.pushViewController(nextViewController, animated: false)
             }
@@ -138,8 +150,9 @@ extension ThirdOnboardingViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if let select = collectionView.indexPathsForSelectedItems {
             if select.count > 0 {
+                selectList.append(ThirdOnboardingModel.titles[indexPath.row].title)
                 self.isTapped = true
-                setUI()
+                updateButton(isTapped: self.isTapped)
             }
         }
     }
@@ -147,8 +160,12 @@ extension ThirdOnboardingViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         if let deSelect = collectionView.indexPathsForSelectedItems {
             if deSelect.count == 0 {
+                if let index = selectList.firstIndex(of: ThirdOnboardingModel.titles[indexPath.row].title) {
+                    selectList.remove(at: index)
+                }
                 self.isTapped = false
-                setUI()
+                updateButton(isTapped: self.isTapped)
+
             }
         }
     }

--- a/iOS-NOTTODO/iOS-NOTTODO/Resource/Info.plist
+++ b/iOS-NOTTODO/iOS-NOTTODO/Resource/Info.plist
@@ -10,9 +10,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>kakaof06c671df540ff4a8f8275f453368748</string>
-			</array>
+			<array/>
 		</dict>
 	</array>
 	<key>LSApplicatioonQueriesSchemes</key>


### PR DESCRIPTION
## 🫧 작업한 내용

- 앰플리튜드 sdk 설치했습니다. 
- 각 뷰마다 앰플리튜드 이벤트 적용했습니다. 
- API_KEY.plist를 만들어서 카카오 api, 앰플리튜드 api를 넣고, .gitignore에 추가해뒀습니다.
## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->


## 📸 스크린샷

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   앰플리튜드 적용 결과          |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/86555102-d0f2-4b4c-a100-5f15b4fc1ee5" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #143
