### PR TITLE
[Fix] #149 - 낫투두 생성 화면전환 플로우 수정 및 낫투두 수정 날짜 토글 수정

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -203,6 +203,7 @@ extension DateCollectionViewCell {
     
     func setDateList(_ dates: [String]) {
         dateList = dates
+        setCellData(dates)
     }
 }
 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -359,6 +359,13 @@ extension AddMissionViewController: UICollectionViewDelegateFlowLayout {
         missionMenuCell.setFoldState(currentFoldState)
         addMissionCollectionView.collectionViewLayout.collectionView?.reloadItems(at: [indexPath])
     }
+    
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        if indexPath.row == 0 && missionType == .update {
+            return false
+        }
+        return true
+    }
 }
 
 extension AddMissionViewController {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Recommend/ViewControllers/RecommendViewController.swift
@@ -191,7 +191,7 @@ extension RecommendViewController: UICollectionViewDelegate {
             viewController.bodyImageUrl = selectedCell.bodyImage.image
             viewController.setSelectDate(self.selectDay ?? "")
             
-            self.navigationController?.pushViewController(viewController, animated: false)
+            self.navigationController?.pushViewController(viewController, animated: true)
         }
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/RecommendAction/ViewControllers/RecommendActionViewController.swift
@@ -7,12 +7,15 @@
 
 import UIKit
 
-class RecommendActionViewController: UIViewController {
+import SnapKit
+import Then
+
+final class RecommendActionViewController: UIViewController {
     
     // MARK: - Properties
     
-    var recommendActionResponse: RecommendActionResponseDTO?
-    var recommendActionList: [RecommendActions] = []
+    private var recommendActionResponse: RecommendActionResponseDTO?
+    private var recommendActionList: [RecommendActions] = []
     var selectedIndex: Int = 0
     var tagLabelText: String?
     var bodyImageUrl: UIImage?
@@ -81,7 +84,7 @@ private extension RecommendActionViewController {
         
         backButton.do {
             $0.setBackgroundImage(.back, for: .normal)
-            $0.addTarget(self, action: #selector(self.popViewController), for: .touchUpInside)
+            $0.addTarget(self, action: #selector(backButtonDidTapped), for: .touchUpInside)
         }
         
         navigationTitle.do {
@@ -132,13 +135,13 @@ private extension RecommendActionViewController {
         }
     }
     
-    private func layout() -> UICollectionViewFlowLayout {
+    func layout() -> UICollectionViewFlowLayout {
         let layout = UICollectionViewFlowLayout()
         layout.minimumLineSpacing = 11
         return layout
     }
     
-    private func register() {
+    func register() {
         recommendActionCollectionView.register(RecommendActionHeaderView.self,
                                                forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
                                                withReuseIdentifier: RecommendActionHeaderView.identifier)
@@ -164,6 +167,11 @@ private extension RecommendActionViewController {
             self?.recommendActionList = data.recommendActions
             self?.recommendActionCollectionView.reloadData()
         }
+    }
+    
+    @objc
+    func backButtonDidTapped() {
+        self.navigationController?.popViewController(animated: true)
     }
 }
 


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 낫투두 생성 화면전환 플로우 수정
- 날짜 토글 비활성화 및 텍스트 분기처리 추가


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   낫투두 생성 화면전환 플로우 수정        |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/40b4ad6e-b770-46da-8eb3-f0fc0b6dcb25" width ="250">|
|   날짜 토글 비활성화 및 텍스트 분기처리 추가       |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/6b3d5f66-dace-45e4-93fb-27f155c70539" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #149
