### PR TITLE
[Fix] #165 - 생성/수정 뷰 UI QA 반영

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
+++ b/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
@@ -1529,7 +1529,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.7;
+				MARKETING_VERSION = 0.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "nottodo.iOS-NOTTODO";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1562,7 +1562,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.0.7;
+				MARKETING_VERSION = 0.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = "nottodo.iOS-NOTTODO";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -80,10 +80,10 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
         } else if checkTomorrow {
             dayLabel.text = I18N.tomorrow
         } else {
-            dayLabel.isHidden = checkToday && checkTomorrow
-            paddingView.isHidden = !(checkToday && checkTomorrow)
+            dayLabel.isHidden = checkToday || checkTomorrow
         }
         
+        paddingView.isHidden = !(checkToday || checkTomorrow)
         otherLabel.isHidden = dateArray.count == 1 ? true : false
         if dateArray.count > 1 {
             otherLabel.text = "외 \(dateArray.count - 1)일"

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/Cells/DateCollectionViewCell.swift
@@ -23,6 +23,7 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     private lazy var tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: today)!
     private var dateList: [String] = []
     private var missionType: MissionType?
+    private var deviceWidth = UIScreen.main.bounds.width
     
     // MARK: - UI Components
     
@@ -55,7 +56,11 @@ final class DateCollectionViewCell: UICollectionViewCell, AddMissionMenu {
     
     func setFoldState(_ state: FoldState) {
         fold = state
-        missionCellHeight?(state == .folded ? 54 : 470)
+        
+        let deviceWidth = UIScreen.main.bounds.width
+        let cellWidth = deviceWidth * (345/375)
+        let cellHeight = cellWidth * (470/345)
+        missionCellHeight?(state == .folded ? 54 : cellHeight)
         updateUI()
         contentView.layoutIfNeeded()
     }
@@ -112,7 +117,7 @@ extension DateCollectionViewCell {
         
         warningLabel.do {
             $0.text = I18N.dateWarning
-            $0.font = .Pretendard(.regular, size: 13)
+            $0.font = .Pretendard(.regular, size: 12)
             $0.textColor = .gray4
             $0.numberOfLines = 0
         }
@@ -177,7 +182,7 @@ extension DateCollectionViewCell {
         [dayLabel, dateLabel, calendarImage, otherLabel].forEach { $0.isHidden = !isHidden }
         titleLabel.setTitleColor(isHidden)
         
-        calendarImage.isHidden = missionType == .update
+        calendarImage.isHidden = missionType == .update || !isHidden
         
         backgroundColor = isHidden ? .clear : .gray1
         layer.borderColor = isHidden ? UIColor.gray2?.cgColor : UIColor.gray3?.cgColor


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 날짜 토글 경고 레이아웃 기기대응
- 수정뷰 날짜 전달이 되지 않거나, 하루 임에도 외 -1일이 뜨는 오류 재수정

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   날짜 토글 경고 레이아웃 기기대응      |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/b2ddfbdc-192c-4e3a-86a4-1a30731d81a7" width ="250">|
|   수정뷰 날짜 전달     |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/45087c52-9ba5-45f3-b699-418366807dac" width ="250">|

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #165
