### PR TITLE
[Fix] #163 - 홈 미션리스트 체크 버튼 터치 영역 수정 

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionListCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionListCollectionViewCell.swift
@@ -17,7 +17,11 @@ final class MissionListCollectionViewCell: UICollectionViewCell {
     static let identifier = "MissionListCollectionViewCell"
     
     var isTappedClosure: ((_ result: Bool, _ userId: Int) -> Void)?
-    var isTapped: Bool = false
+    var isTapped: Bool = false {
+        didSet {
+            setUI()
+        }
+    }
     var userId: Int = 0
     
     // MARK: - UI Components
@@ -37,6 +41,7 @@ final class MissionListCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: .zero)
         
+        setUI()
         setLayout()
     }
     
@@ -61,11 +66,9 @@ extension MissionListCollectionViewCell {
         contentView.layer.cornerRadius = 10
 
         checkButton.do {
-            $0.backgroundColor = isTapped ? .clear : .white
-            $0.layer.cornerRadius = 6
-            $0.layer.borderWidth = isTapped ? 0 : 0.5
-            $0.layer.borderColor = isTapped ? UIColor.clear.cgColor : UIColor.gray4?.cgColor
-            $0.setImage(isTapped ? UIImage.checkboxFill : nil, for: .normal)
+            $0.backgroundColor = .clear
+            $0.setImage(UIImage.checkbox, for: .normal)
+            $0.setImage(UIImage.checkboxFill, for: .selected)
             $0.addTarget(self, action: #selector(checkBoxButton), for: .touchUpInside)
         }
         
@@ -95,7 +98,7 @@ extension MissionListCollectionViewCell {
         checkButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(20)
             $0.centerY.equalToSuperview()
-            $0.size.equalTo(CGSize(width: 21, height: 21))
+            $0.size.equalTo(41)
         }
         
         tagLabel.snp.makeConstraints {
@@ -124,7 +127,7 @@ extension MissionListCollectionViewCell {
         case .UNCHECKED:  isTapped = false
         case .CHECKED: isTapped = true
         }
-        setUI()
+        checkButton.isSelected = isTapped
     }
     
     @objc

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionListCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionListCollectionViewCell.swift
@@ -103,7 +103,7 @@ extension MissionListCollectionViewCell {
         
         tagLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(18)
-            $0.leading.equalTo(checkButton.snp.trailing).offset(18)
+            $0.leading.equalTo(checkButton.snp.trailing).offset(8)
         }
         
         missionLabel.snp.makeConstraints {

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -134,11 +134,9 @@ extension HomeViewController {
                     if result {
                         self.requestPatchUpdateMissionAPI(id: id, status: CompletionStatus.UNCHECKED )
                         AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Home.completeCheckMission(title: self.missionList[indexPath.row].title, situation: self.missionList[indexPath.row].situationName))
-                        cell.setUI()
                     } else {
                         self.requestPatchUpdateMissionAPI(id: id, status: CompletionStatus.CHECKED )
                         AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Home.completeCheckMission(title: self.missionList[indexPath.row].title, situation: self.missionList[indexPath.row].situationName))
-                        cell.setUI()
                     }
                 }
                 return cell


### PR DESCRIPTION
## 🫧 작업한 내용

- 홈 미션 리스트 체크 버튼 영역 수정했습니다.
## 🔫 PR Point



## 📸 스크린샷

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|  터치 영역         |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/7107c29f-3ddc-4827-b53b-77e36232a4ea" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #163
