### PR TITLE
[Feat] #185 - 푸시 알림 구현

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
+++ b/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
@@ -88,10 +88,10 @@
 		3B14A13F29A6FCB300F92897 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B14A13E29A6FCB300F92897 /* UIStackView+.swift */; };
 		3B14A14129A6FDA900F92897 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B14A14029A6FDA900F92897 /* UILabel+.swift */; };
 		3B14A14329A6FEE400F92897 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B14A14229A6FEE400F92897 /* UITextField+.swift */; };
-		3B288C282AEC355500D1D1DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B288C272AEC355500D1D1DF /* GoogleService-Info.plist */; };
 		3B2B59442AEB814B00B4619A /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 3B2B59432AEB814B00B4619A /* FirebaseMessaging */; };
 		3B37AE2929C8821600AB7587 /* GoalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B37AE2829C8821600AB7587 /* GoalCollectionViewCell.swift */; };
 		3B37AE2B29C8904800AB7587 /* RecommendKeywordCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B37AE2A29C8904800AB7587 /* RecommendKeywordCollectionViewCell.swift */; };
+		3B3EF2F82AF35C90001F79BC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3EF2F72AF35C90001F79BC /* GoogleService-Info.plist */; };
 		3B482FA3299EA9CB00BCF424 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B482FA2299EA9CB00BCF424 /* TabBarItem.swift */; };
 		3B482FA5299EAB8800BCF424 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B482FA4299EAB8800BCF424 /* TabBarController.swift */; };
 		3B482FA7299EB8FD00BCF424 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B482FA6299EB8FD00BCF424 /* UIViewController+.swift */; };
@@ -244,9 +244,9 @@
 		3B14A13E29A6FCB300F92897 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		3B14A14029A6FDA900F92897 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		3B14A14229A6FEE400F92897 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
-		3B288C272AEC355500D1D1DF /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3B37AE2829C8821600AB7587 /* GoalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCollectionViewCell.swift; sourceTree = "<group>"; };
 		3B37AE2A29C8904800AB7587 /* RecommendKeywordCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendKeywordCollectionViewCell.swift; sourceTree = "<group>"; };
+		3B3EF2F72AF35C90001F79BC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3B482FA2299EA9CB00BCF424 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
 		3B482FA4299EAB8800BCF424 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		3B482FA6299EB8FD00BCF424 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
@@ -757,8 +757,8 @@
 			isa = PBXGroup;
 			children = (
 				6CBE702C2A5AA29E00A7EC30 /* API_KEY.plist */,
+				3B3EF2F72AF35C90001F79BC /* GoogleService-Info.plist */,
 				3B027A85299C31B600BEB65C /* Info.plist */,
-				3B288C272AEC355500D1D1DF /* GoogleService-Info.plist */,
 				3B027AAA299C35D000BEB65C /* Assets */,
 				3B027AA9299C35CB00BEB65C /* Colors */,
 				3B027AA8299C35C500BEB65C /* Fonts */,
@@ -1200,7 +1200,7 @@
 				3B710A5C2A62D4AB00E95620 /* Settings.bundle in Resources */,
 				3B027A84299C31B600BEB65C /* LaunchScreen.storyboard in Resources */,
 				6CC54C1A2A28C3AE00AAD76D /* value.json in Resources */,
-				3B288C282AEC355500D1D1DF /* GoogleService-Info.plist in Resources */,
+				3B3EF2F82AF35C90001F79BC /* GoogleService-Info.plist in Resources */,
 				6C049A312A595C670085E40B /* logo.mp4 in Resources */,
 				3B027A81299C31B600BEB65C /* Assets.xcassets in Resources */,
 				3B146D9A299D079D00B17B62 /* Pretendard-Light.otf in Resources */,

--- a/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
+++ b/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		3B14A13F29A6FCB300F92897 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B14A13E29A6FCB300F92897 /* UIStackView+.swift */; };
 		3B14A14129A6FDA900F92897 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B14A14029A6FDA900F92897 /* UILabel+.swift */; };
 		3B14A14329A6FEE400F92897 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B14A14229A6FEE400F92897 /* UITextField+.swift */; };
+		3B288C282AEC355500D1D1DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B288C272AEC355500D1D1DF /* GoogleService-Info.plist */; };
+		3B2B59442AEB814B00B4619A /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 3B2B59432AEB814B00B4619A /* FirebaseMessaging */; };
 		3B37AE2929C8821600AB7587 /* GoalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B37AE2829C8821600AB7587 /* GoalCollectionViewCell.swift */; };
 		3B37AE2B29C8904800AB7587 /* RecommendKeywordCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B37AE2A29C8904800AB7587 /* RecommendKeywordCollectionViewCell.swift */; };
 		3B482FA3299EA9CB00BCF424 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B482FA2299EA9CB00BCF424 /* TabBarItem.swift */; };
@@ -242,6 +244,7 @@
 		3B14A13E29A6FCB300F92897 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		3B14A14029A6FDA900F92897 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		3B14A14229A6FEE400F92897 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
+		3B288C272AEC355500D1D1DF /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3B37AE2829C8821600AB7587 /* GoalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCollectionViewCell.swift; sourceTree = "<group>"; };
 		3B37AE2A29C8904800AB7587 /* RecommendKeywordCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendKeywordCollectionViewCell.swift; sourceTree = "<group>"; };
 		3B482FA2299EA9CB00BCF424 /* TabBarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
@@ -322,6 +325,7 @@
 				6C44127129A35A1000313C3F /* KakaoSDK in Frameworks */,
 				3B146DA4299D0A8600B17B62 /* Then in Frameworks */,
 				3B146DA7299D0AA300B17B62 /* Moya in Frameworks */,
+				3B2B59442AEB814B00B4619A /* FirebaseMessaging in Frameworks */,
 				6C44127729A35A1000313C3F /* KakaoSDKNavi in Frameworks */,
 				6C44128129A35A1000313C3F /* KakaoSDKUser in Frameworks */,
 				6C44127D29A35A1000313C3F /* KakaoSDKTalk in Frameworks */,
@@ -754,6 +758,7 @@
 			children = (
 				6CBE702C2A5AA29E00A7EC30 /* API_KEY.plist */,
 				3B027A85299C31B600BEB65C /* Info.plist */,
+				3B288C272AEC355500D1D1DF /* GoogleService-Info.plist */,
 				3B027AAA299C35D000BEB65C /* Assets */,
 				3B027AA9299C35CB00BEB65C /* Colors */,
 				3B027AA8299C35C500BEB65C /* Fonts */,
@@ -1133,6 +1138,7 @@
 				6C9628A62A22208F003ADE25 /* Lottie */,
 				0943A9F42A531D0000614761 /* Amplitude */,
 				09C8602C2AB14B4800C4F4B1 /* FSCalendar */,
+				3B2B59432AEB814B00B4619A /* FirebaseMessaging */,
 			);
 			productName = "iOS-NOTTODO";
 			productReference = 3B027A74299C31B500BEB65C /* iOS-NOTTODO.app */;
@@ -1171,6 +1177,7 @@
 				6C9628A52A22208F003ADE25 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				0943A9F32A531D0000614761 /* XCRemoteSwiftPackageReference "Amplitude-iOS" */,
 				09C8602B2AB14B4700C4F4B1 /* XCRemoteSwiftPackageReference "FSCalendar" */,
+				3B2B59422AEB814B00B4619A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 3B027A75299C31B500BEB65C /* Products */;
 			projectDirPath = "";
@@ -1193,6 +1200,7 @@
 				3B710A5C2A62D4AB00E95620 /* Settings.bundle in Resources */,
 				3B027A84299C31B600BEB65C /* LaunchScreen.storyboard in Resources */,
 				6CC54C1A2A28C3AE00AAD76D /* value.json in Resources */,
+				3B288C282AEC355500D1D1DF /* GoogleService-Info.plist in Resources */,
 				6C049A312A595C670085E40B /* logo.mp4 in Resources */,
 				3B027A81299C31B600BEB65C /* Assets.xcassets in Resources */,
 				3B146D9A299D079D00B17B62 /* Pretendard-Light.otf in Resources */,
@@ -1510,7 +1518,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "nottodo.iOS-NOTTODO";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1547,7 +1555,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "nottodo.iOS-NOTTODO";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1625,6 +1633,14 @@
 				kind = branch;
 			};
 		};
+		3B2B59422AEB814B00B4619A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.0.0;
+			};
+		};
 		6C44126F29A35A1000313C3F /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
@@ -1676,6 +1692,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3B146DA5299D0AA300B17B62 /* XCRemoteSwiftPackageReference "Moya" */;
 			productName = Moya;
+		};
+		3B2B59432AEB814B00B4619A /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3B2B59422AEB814B00B4619A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 		6C44127029A35A1000313C3F /* KakaoSDK */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
@@ -113,12 +113,12 @@ extension AppDelegate: MessagingDelegate {
 extension AppDelegate: UNUserNotificationCenterDelegate {
 
     /// foreground에서 러닝 중에 앱에 도착하는 알림을 다루는 메서드
-    func userNotificationCenter(_ center: UNUserNotificationCenter,willPresent notification: UNNotification,withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.alert, .sound, .badge])
     }
 
     /// 도착한 notification에 대한 유저의 반응을 다루는 메서드
-    func userNotificationCenter(_ center: UNUserNotificationCenter,didReceive response: UNNotificationResponse,withCompletionHandler completionHandler: @escaping () -> Void) {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         completionHandler()
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Application/AppDelegate.swift
@@ -114,7 +114,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
     /// foreground에서 러닝 중에 앱에 도착하는 알림을 다루는 메서드
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([.alert, .sound, .badge])
+        completionHandler([.list, .sound, .badge, .banner])
     }
 
     /// 도착한 notification에 대한 유저의 반응을 다루는 메서드

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/DefaultKeys.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/DefaultKeys.swift
@@ -26,5 +26,5 @@ struct DefaultKeys {
     static let isAppleLogin = "isAppleLogin"
     static let socialToken = "socialToken"
     static let accessToken = "accessToken"
-    static let fcmToken = "1"
+    static let fcmToken = "fcmToken"
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/KeychainUtil.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/KeychainUtil.swift
@@ -15,6 +15,9 @@ public final class KeychainUtil {
     static func setAccessToken(_ token: String) {
         UserDefaults.standard.setValue(token, forKey: DefaultKeys.accessToken)
     }
+    static func setFcmToken(_ token: String) {
+        UserDefaults.standard.setValue(token, forKey: DefaultKeys.fcmToken)
+    }
     static func setString(_ value: String?, forKey key: String) {
         UserDefaults.standard.setValue(value, forKey: key)
     }
@@ -26,6 +29,9 @@ public final class KeychainUtil {
     }
     static func getAccessToken() -> String {
         UserDefaults.standard.string(forKey: DefaultKeys.accessToken) ?? ""
+    }
+    static func getFcmToken() -> String {
+        UserDefaults.standard.string(forKey: DefaultKeys.fcmToken) ?? ""
     }
     static func getKakaoNickname() -> String {
         UserDefaults.standard.string(forKey: DefaultKeys.kakaoNickname) ?? "익명의 도전자"

--- a/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/KeychainUtil.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Global/Enum/KeychainUtil.swift
@@ -45,4 +45,17 @@ public final class KeychainUtil {
     static func getAppleEmail() -> String {
         UserDefaults.standard.string(forKey: DefaultKeys.appleEmail) ?? "연동된 이메일 정보가 없습니다"
     }
+    
+    static func removeUserInfo() {
+        if UserDefaults.standard.bool(forKey: DefaultKeys.isAppleLogin) {
+            UserDefaults.standard.removeObject(forKey: DefaultKeys.appleName)
+            UserDefaults.standard.removeObject(forKey: DefaultKeys.appleEmail)
+        } else {
+            UserDefaults.standard.removeObject(forKey: DefaultKeys.kakaoEmail)
+            UserDefaults.standard.removeObject(forKey: DefaultKeys.kakaoNickname)
+        }
+        
+        UserDefaults.standard.removeObject(forKey: DefaultKeys.socialToken)
+        UserDefaults.standard.removeObject(forKey: DefaultKeys.accessToken)
+    }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
@@ -231,7 +231,7 @@ extension AuthViewController {
                 KeychainUtil.setString(email, forKey: DefaultKeys.kakaoEmail)
                 KeychainUtil.setBool(false, forKey: DefaultKeys.isAppleLogin)
                 
-                AuthAPI.shared.postKakaoAuth(social: LoginType.Kakao.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken) { [weak self] result in
+                AuthAPI.shared.postKakaoAuth(social: LoginType.Kakao.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: KeychainUtil.getFcmToken()) { [weak self] result in
                     guard self != nil else { return }
                     guard result != nil else { return }
                     
@@ -240,7 +240,7 @@ extension AuthViewController {
                     guard let accessToken = result?.data?.accessToken else { return }
                     guard let userId = result?.data?.userId else { return }
                     KeychainUtil.setAccessToken(accessToken)
-                    Amplitude.instance().setUserId(result?.data?.userId)
+                    Amplitude.instance().setUserId(userId)
                     self?.presentToHomeViewController()
                     
                 }
@@ -289,7 +289,7 @@ extension AuthViewController: ASAuthorizationControllerDelegate, ASAuthorization
             
             KeychainUtil.setBool(true, forKey: DefaultKeys.isAppleLogin)
 
-            AuthAPI.shared.postAppleAuth(social: LoginType.Apple.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: DefaultKeys.fcmToken, name: KeychainUtil.getAppleUsername()) { [weak self] result in
+            AuthAPI.shared.postAppleAuth(social: LoginType.Apple.social, socialToken: KeychainUtil.getSocialToken(), fcmToken: KeychainUtil.getFcmToken(), name: KeychainUtil.getAppleUsername()) { [weak self] result in
                 guard self != nil else { return }
                 guard result != nil else { return }
                 

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Modal/NottodoModalViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Modal/NottodoModalViewController.swift
@@ -113,10 +113,7 @@ extension NottodoModalViewController {
             kakaoWithdrawal()
         }
         AuthAPI.shared.withdrawalAuth { _ in
-            for key in UserDefaults.standard.dictionaryRepresentation().keys where key != DefaultKeys.fcmToken {
-                UserDefaults.standard.removeObject(forKey: key.description)
-            }
-            UserDefaults.standard.removeObject(forKey: DefaultKeys.accessToken)
+            KeychainUtil.removeUserInfo()
             AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.AccountInfo.completeWithdrawal)
         }
     }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Modal/NottodoModalViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Modal/NottodoModalViewController.swift
@@ -113,10 +113,8 @@ extension NottodoModalViewController {
             kakaoWithdrawal()
         }
         AuthAPI.shared.withdrawalAuth { _ in
-            for key in UserDefaults.standard.dictionaryRepresentation().keys {
-                if key != DefaultKeys.fcmToken {
-                    UserDefaults.standard.removeObject(forKey: key.description)
-                }
+            for key in UserDefaults.standard.dictionaryRepresentation().keys where key != DefaultKeys.fcmToken {
+                UserDefaults.standard.removeObject(forKey: key.description)
             }
             UserDefaults.standard.removeObject(forKey: DefaultKeys.accessToken)
             AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.AccountInfo.completeWithdrawal)

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Modal/NottodoModalViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Modal/NottodoModalViewController.swift
@@ -114,7 +114,9 @@ extension NottodoModalViewController {
         }
         AuthAPI.shared.withdrawalAuth { _ in
             for key in UserDefaults.standard.dictionaryRepresentation().keys {
-                UserDefaults.standard.removeObject(forKey: key.description)
+                if key != DefaultKeys.fcmToken {
+                    UserDefaults.standard.removeObject(forKey: key.description)
+                }
             }
             UserDefaults.standard.removeObject(forKey: DefaultKeys.accessToken)
             AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.AccountInfo.completeWithdrawal)

--- a/iOS-NOTTODO/iOS-NOTTODO/Resource/GoogleService-Info.plist
+++ b/iOS-NOTTODO/iOS-NOTTODO/Resource/GoogleService-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>120132434956-pdl1h524j5dopurfep91ubvb83u7uik5.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.120132434956-pdl1h524j5dopurfep91ubvb83u7uik5</string>
+	<key>ANDROID_CLIENT_ID</key>
+	<string>120132434956-gu050quhmujgp82frjagd111bv69vcst.apps.googleusercontent.com</string>
+	<key>API_KEY</key>
+	<string>AIzaSyCpgIvJDISfAqCwZgHydtINHX-_ggXGt6E</string>
+	<key>GCM_SENDER_ID</key>
+	<string>120132434956</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>nottodo.iOS-NOTTODO</string>
+	<key>PROJECT_ID</key>
+	<string>not-to-do-2a651</string>
+	<key>STORAGE_BUCKET</key>
+	<string>not-to-do-2a651.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false/>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false/>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true/>
+	<key>IS_GCM_ENABLED</key>
+	<true/>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true/>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:120132434956:ios:e1ca7f7e5f4887200d4229</string>
+</dict>
+</plist>

--- a/iOS-NOTTODO/iOS-NOTTODO/Resource/Info.plist
+++ b/iOS-NOTTODO/iOS-NOTTODO/Resource/Info.plist
@@ -45,5 +45,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/iOS-NOTTODO/iOS-NOTTODO/Resource/Info.plist
+++ b/iOS-NOTTODO/iOS-NOTTODO/Resource/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
 	<key>CFBundleURLTypes</key>

--- a/iOS-NOTTODO/iOS-NOTTODO/iOS-NOTTODO.entitlements
+++ b/iOS-NOTTODO/iOS-NOTTODO/iOS-NOTTODO.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 푸시 알림을 구현했습니다.

## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 회원탈퇴 앱을 끄지 않은 상태로 소셜로그인을 진행할 때 fcmToken을 전달해주기 위해 NottodoModalViewController의 withdraw() 함수 내에서 key가 fcmToken일 때는 초기화하지 않도록 코드를 수정하였는데,, 혹시 더 좋은 방법이 있는지 궁금합니다!


## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|     구현 내용     |   스크린샷   |
| :-------------: | :----------: |
|   푸시 알림         |<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/65678579/eb144411-1cf2-4961-80b7-7dc07e8bebc7" width ="250">|


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #185
