### PR TITLE
[Refactor] #197 - 미션 리스트 디테일 UI 로직 변경

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
+++ b/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		0943A9F92A53239200614761 /* Bundle+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0943A9F82A53239200614761 /* Bundle+.swift */; };
 		09582B4829BDA7F600EF3207 /* DetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09582B4729BDA7F600EF3207 /* DetailStackView.swift */; };
 		09582B4B29BDE37C00EF3207 /* DetailFooterReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09582B4A29BDE37C00EF3207 /* DetailFooterReusableView.swift */; };
-		09582B4D29BE277800EF3207 /* DetailHeaderReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09582B4C29BE277800EF3207 /* DetailHeaderReusableView.swift */; };
+		09582B4D29BE277800EF3207 /* DetailHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09582B4C29BE277800EF3207 /* DetailHeaderView.swift */; };
 		09582B4F29BEBAFA00EF3207 /* DetailCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09582B4E29BEBAFA00EF3207 /* DetailCalendarViewController.swift */; };
 		09582B5129C0BC3600EF3207 /* DetailAchievementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09582B5029C0BC3600EF3207 /* DetailAchievementViewController.swift */; };
 		0960C0D42A38BC6500A3D8DB /* KeychainUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0960C0D32A38BC6500A3D8DB /* KeychainUtil.swift */; };
@@ -183,7 +183,7 @@
 		0943A9F82A53239200614761 /* Bundle+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+.swift"; sourceTree = "<group>"; };
 		09582B4729BDA7F600EF3207 /* DetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailStackView.swift; sourceTree = "<group>"; };
 		09582B4A29BDE37C00EF3207 /* DetailFooterReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailFooterReusableView.swift; sourceTree = "<group>"; };
-		09582B4C29BE277800EF3207 /* DetailHeaderReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailHeaderReusableView.swift; sourceTree = "<group>"; };
+		09582B4C29BE277800EF3207 /* DetailHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailHeaderView.swift; sourceTree = "<group>"; };
 		09582B4E29BEBAFA00EF3207 /* DetailCalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCalendarViewController.swift; sourceTree = "<group>"; };
 		09582B5029C0BC3600EF3207 /* DetailAchievementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailAchievementViewController.swift; sourceTree = "<group>"; };
 		0960C0D32A38BC6500A3D8DB /* KeychainUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainUtil.swift; sourceTree = "<group>"; };
@@ -465,7 +465,7 @@
 				097C003529AB8270008CAEF3 /* MissionListCollectionViewCell.swift */,
 				092E04B029BD9C86008A5892 /* MissionDetailCollectionViewCell.swift */,
 				09582B4A29BDE37C00EF3207 /* DetailFooterReusableView.swift */,
-				09582B4C29BE277800EF3207 /* DetailHeaderReusableView.swift */,
+				09582B4C29BE277800EF3207 /* DetailHeaderView.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -1327,7 +1327,7 @@
 				3BBB6C8F2A1E7BEA00B8745A /* CollectionViewLeftAlignLayout.swift in Sources */,
 				09A1465F2A192C4900DDC308 /* WeekMissionResponseDTO.swift in Sources */,
 				0930D37329B4FCAE0000C4AE /* StatisticsView.swift in Sources */,
-				09582B4D29BE277800EF3207 /* DetailHeaderReusableView.swift in Sources */,
+				09582B4D29BE277800EF3207 /* DetailHeaderView.swift in Sources */,
 				6CF4706A29A71D71008D145C /* Strings.swift in Sources */,
 				6CF4705F29A69025008D145C /* GeneralResponse.swift in Sources */,
 				097C003629AB8270008CAEF3 /* MissionListCollectionViewCell.swift in Sources */,

--- a/iOS-NOTTODO/iOS-NOTTODO/Network/API/Home/HomeAPI.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Network/API/Home/HomeAPI.swift
@@ -55,16 +55,20 @@ final class HomeAPI {
         }
     }
     
-    func getDailyDetailMission(id: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
-        homeProvider.request(.dailyDetailMission(id: id)) { response in
-            switch response {
-            case let .success(response):
-                let statusCode = response.statusCode
-                let data = response.data
-                let networkResult = NetworkBase.judgeStatus(by: statusCode, data, MissionDetailResponseDTO.self)
-                completion(networkResult)
-            case let .failure(err):
-                print(err)
+    func getDailyDetailMission(id: Int, completion: @escaping (GeneralResponse<MissionDetailResponseDTO>?) -> Void) {
+        homeProvider.request(.dailyDetailMission(id: id)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    self.missionDetailDailyData = try response.map(GeneralResponse<MissionDetailResponseDTO>?.self)
+                    guard let missionDetailDailyData = self.missionDetailDailyData else { return }
+                    completion(missionDetailDailyData)
+                } catch let err {
+                    print(err.localizedDescription, 500)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
             }
         }
     }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -319,27 +319,15 @@ extension AddMissionViewController {
     }
     
     private func requestDailyMissionAPI(id: Int) {
-        HomeAPI.shared.getDailyDetailMission(id: id) { [weak self] result in
-            switch result {
-            case let .success(data):
-                if let missionData = data as? MissionDetailResponseDTO {
-                    self?.nottodoInfoList[1] = missionData.title
-                    self?.nottodoInfoList[2] = missionData.situation
-                    self?.nottodoInfoList[3] = missionData.actions.first!.name
-                    self?.nottodoInfoList[4] = missionData.goal
-                    self?.addMissionCollectionView.reloadData()
-                } else {
-                    print("Failed to cast data to MissionDetailResponseDTO")
-                }
-            case .pathErr:
-                print("pathErr")
-            case .serverErr:
-                print("serverErr")
-            case .networkFail:
-                print("networkFail")
-            case .requestErr:
-                print("networkFail")
-            }
+        HomeAPI.shared.getDailyDetailMission(id: id) { [weak self] response in
+            guard let self else { return }
+            guard let response = response else { return }
+            guard let data = response.data else { return }
+            self.nottodoInfoList[1] = data.title
+            self.nottodoInfoList[2] = data.situation
+            self.nottodoInfoList[3] = data.actions.first!.name
+            self.nottodoInfoList[4] = data.goal
+            self.addMissionCollectionView.reloadData()
         }
     }
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Calendar/CalendarView.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Common/Calendar/CalendarView.swift
@@ -140,6 +140,8 @@ extension CalendarView {
     }
 }
 
+// MARK: - Action
+
 extension CalendarView {
 
     @objc
@@ -151,10 +153,36 @@ extension CalendarView {
     func nextBtnTapped(_sender: UIButton) {
         scrollCurrentPage(calendar: calendar, isPrev: false)
     }
+}
+
+extension CalendarView {
     
     func setCalendarSelectedDate(_ dates: [Date]) {
         dates.forEach {
             calendar.select($0)
         }
     }
+    
+    func configure(delegate: FSCalendarDelegate, datasource: FSCalendarDataSource) {
+        calendar.delegate = delegate
+        calendar.dataSource = datasource
+    }
+    
+    func configureYearMonth(to text: String) {
+        yearMonthLabel.text = text
+    }
+    
+    func reloadCollectionView() {
+        calendar.collectionView.reloadData()
+    }
+    
+    func updateDetailConstraints() {
+        horizonStackView.snp.updateConstraints {
+            $0.top.equalToSuperview().offset(54)
+        }
+        calendar.snp.updateConstraints {
+            $0.bottom.equalToSuperview().inset(45)
+        }
+    }
+    
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/DetailFooterReusableView.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/DetailFooterReusableView.swift
@@ -10,11 +10,12 @@ import UIKit
 import SnapKit
 import Then
 
-final class DetailFooterReusableView: UICollectionReusableView {
+final class DetailFooterView: UICollectionReusableView {
     
     // MARK: - Properties
     
     static let identifier = "DetailFooterReusableView"
+    
     var footerClosure: (() -> Void)?
     
     // MARK: - UI Components
@@ -23,6 +24,7 @@ final class DetailFooterReusableView: UICollectionReusableView {
     private let dateButton = UIButton(configuration: .plain())
     
     // MARK: - Life Cycle
+    
     override init(frame: CGRect) {
         super.init(frame: .zero)
         setUI()
@@ -37,7 +39,7 @@ final class DetailFooterReusableView: UICollectionReusableView {
 
 // MARK: - Method
 
-extension DetailFooterReusableView {
+extension DetailFooterView {
     private func setUI() {
         dateLabel.do {
             $0.text = I18N.detailDate

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/DetailHeaderView.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/DetailHeaderView.swift
@@ -10,24 +10,23 @@ import UIKit
 import SnapKit
 import Then
 
-final class DetailHeaderReusableView: UICollectionReusableView {
+final class DetailHeaderView: UIView {
     
     // MARK: - Properties
     
-    static let identifier = "DetailHeaderReusableView"
     var cancelClosure: (() -> Void)?
     var editClosure: (() -> Void)?
     
     // MARK: - UI Components
-    
-    private let horizontalStackview = UIStackView()
-    private let emptyView = UIView()
+
     private let cancelButton = UIButton()
     private let editButton = UIButton()
     
     // MARK: - Life Cycle
+    
     override init(frame: CGRect) {
         super.init(frame: .zero)
+        
         setUI()
         setLayout()
     }
@@ -40,41 +39,36 @@ final class DetailHeaderReusableView: UICollectionReusableView {
 
 // MARK: - Method
 
-extension DetailHeaderReusableView {
+extension DetailHeaderView {
+    
     private func setUI() {
         cancelButton.do {
             $0.backgroundColor = .clear
             $0.setImage(.icCancel, for: .normal)
             $0.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
         }
+        
         editButton.do {
             $0.setTitle(I18N.detailEdit, for: .normal)
             $0.setTitleColor(.gray4, for: .normal)
             $0.titleLabel?.font = .Pretendard(.medium, size: 16)
             $0.addTarget(self, action: #selector(editButtonTapped), for: .touchUpInside)
         }
-        horizontalStackview.do {
-            $0.addArrangedSubviews(cancelButton, emptyView, editButton)
-            $0.axis = .horizontal
-        }
     }
     
     private func setLayout() {
-        addSubview(horizontalStackview)
+        addSubviews(cancelButton, editButton)
 
         cancelButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.size.equalTo(CGSize(width: 24, height: 24))
-            $0.leading.equalToSuperview().offset(7)
+            $0.leading.equalToSuperview().inset(24)
         }
+        
         editButton.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.size.equalTo(CGSize(width: 44, height: 35))
-        }
-        horizontalStackview.snp.makeConstraints {
-            $0.directionalHorizontalEdges.equalToSuperview().inset(17)
-            $0.top.equalToSuperview().offset(-5)
-            $0.height.equalTo(35)
+            $0.trailing.equalToSuperview().inset(17)
         }
     }
     

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionDetailCollectionViewCell.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/Cells/MissionDetailCollectionViewCell.swift
@@ -92,7 +92,7 @@ extension MissionDetailCollectionViewCell {
         accumulateView.addSubviews(accumulateSubView, accumulateLabel)
         
         missionTagLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(30)
+            $0.top.equalToSuperview()
             $0.leading.equalToSuperview().offset(29)
         }
         

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/DetailCalendarViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/DetailCalendarViewController.swift
@@ -22,10 +22,11 @@ final class DetailCalendarViewController: UIViewController {
     }
     var invalidDate: [String] = []
     var dataSource: [String: Float] = [:]
-    var detailModel: [MissionDetailResponseDTO] = []
+    var detailModel: MissionDetailResponseDTO?
     var userId: Int?
     var count: Int?
     var movedateClosure: ((_ date: String) -> Void)?
+    
     private lazy var safeArea = self.view.safeAreaLayoutGuide
     private lazy var today: Date = { return Date() }()
 
@@ -40,6 +41,7 @@ final class DetailCalendarViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.SelectDate.appearAnotherDayModal)
+        
         if let id = self.userId {
             requestParticualrDatesAPI(id: id)
         }
@@ -47,6 +49,7 @@ final class DetailCalendarViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         setUI()
         setLayout()
     }
@@ -73,12 +76,14 @@ extension DetailCalendarViewController {
             $0.setTitle(I18N.detailComplete, for: .normal)
             $0.titleLabel?.font = .Pretendard(.medium, size: 16)
             $0.addTarget(self, action: #selector(completeBtnTapped(sender:)), for: .touchUpInside)
+
         }
+        
         monthCalendar.do {
             $0.layer.cornerRadius = 12
-            $0.calendar.delegate = self
-            $0.calendar.dataSource = self
+            $0.configure(delegate: self, datasource: self)
         }
+        
         subLabel.do {
             $0.text = I18N.subText
             $0.font = .Pretendard(.regular, size: 12)
@@ -109,19 +114,15 @@ extension DetailCalendarViewController {
             $0.trailing.equalToSuperview().inset(16)
             $0.size.equalTo(CGSize(width: 44, height: 35))
         }
-        
-        monthCalendar.horizonStackView.snp.updateConstraints {
-            $0.top.equalToSuperview().offset(54)
-        }
-        
+ 
         monthCalendar.snp.makeConstraints {
             $0.centerY.equalTo(safeArea)
             $0.directionalHorizontalEdges.equalTo(safeArea).inset(15)
             $0.height.equalTo((getDeviceWidth()-30)*1.2)
         }
-        monthCalendar.calendar.snp.updateConstraints {
-            $0.bottom.equalToSuperview().inset(45)
-        }
+        
+        monthCalendar.updateDetailConstraints()
+       
         subLabel.snp.makeConstraints {
             $0.bottom.equalToSuperview().inset(25)
             $0.left.equalToSuperview().offset(17)
@@ -130,11 +131,17 @@ extension DetailCalendarViewController {
 }
 
 extension DetailCalendarViewController {
+    
     @objc
     func completeBtnTapped(sender: UIButton) {
+        guard let data = self.detailModel else { return }
         if let id = self.userId {
             requestAddAnotherDay(id: id, dates: anotherDate)
-            AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.SelectDate.completeAddMissionAnotherDay(title: self.detailModel[0].title, situation: self.detailModel[0].situation, goal: self.detailModel[0].goal, action: [self.detailModel[0].actions[0].name], date: anotherDate))
+            AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.SelectDate.completeAddMissionAnotherDay(title: data.title,
+                                                                                                                situation: data.situation,
+                                                                                                                goal: data.goal,
+                                                                                                                action: data.actions.map { $0.name }
+                                                                                                                , date: anotherDate))
         }
     }
 }
@@ -142,7 +149,8 @@ extension DetailCalendarViewController {
 extension DetailCalendarViewController: FSCalendarDelegate, FSCalendarDataSource, FSCalendarDelegateAppearance {
     
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
-        monthCalendar.yearMonthLabel.text = Utils.dateFormatterString(format: I18N.yearMonthTitle, date: calendar.currentPage)
+        monthCalendar.configureYearMonth(to: Utils.dateFormatterString(format: I18N.yearMonthTitle,
+                                                                       date: calendar.currentPage))
         guard let id = self.userId else { return }
         requestParticualrDatesAPI(id: id)
     }
@@ -218,7 +226,7 @@ extension DetailCalendarViewController {
         HomeAPI.shared.particularMissionDates(id: id) { [weak self] response in
             guard let dates = response.data else { return }
             self?.invalidDate = dates
-            self?.monthCalendar.calendar.reloadData()
+            self?.monthCalendar.reloadCollectionView()
         }
     }
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/MissionDetailViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/MissionDetailViewController.swift
@@ -10,158 +10,199 @@ import UIKit
 import Then
 import SnapKit
 
+import UIKit
+
+import Then
+import SnapKit
+
 final class MissionDetailViewController: UIViewController {
     
     // MARK: - Properties
+    
+    typealias CellRegistration = UICollectionView.CellRegistration
+    typealias FooterRegistration = UICollectionView.SupplementaryRegistration
+    typealias Item = MissionDetailResponseDTO
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+    typealias SnapShot = NSDiffableDataSourceSnapshot<Section, Item>
+    
+    enum Section {
+        case main
+    }
+    
+    private var dataSource: DataSource?
+    private var detailModel: MissionDetailResponseDTO?
+    var userId: Int?
     
     var deleteClosure: (() -> Void)?
     var moveDateClosure: ((_ date: String) -> Void)?
     
     private lazy var safeArea = self.view.safeAreaLayoutGuide
-    enum Section {
-        case mission
-    }
-    typealias Item = AnyHashable
-    var dataSource: UICollectionViewDiffableDataSource<Section, Item>! = nil
-    var detailModel: [MissionDetailResponseDTO] = []
-    var userId: Int?
     
     // MARK: - UI Components
     
+    private let headerView = DetailHeaderView()
     private let deleteButton = UIButton(configuration: .filled())
-    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout())
-    private let completeButton = UIButton()
+    private var collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init())
     
     // MARK: - Life Cycle
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
         guard let id = self.userId else { return }
         requestDailyMissionAPI(id: id)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        register()
+        
         setUI()
         setLayout()
         setupDataSource()
-        reloadData()
+        setSnapShot()
     }
 }
 
 // MARK: - Methods
 
 extension MissionDetailViewController {
-    private func register() {
-        collectionView.register(MissionDetailCollectionViewCell.self, forCellWithReuseIdentifier: MissionDetailCollectionViewCell.identifier)
-        collectionView.register(DetailHeaderReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: DetailHeaderReusableView.identifier)
-        collectionView.register(DetailFooterReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: DetailFooterReusableView.identifier)
-    }
+    
     private func setUI() {
+        
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.25) {
             UIView.animate(withDuration: 0.5) {
                 self.view.backgroundColor = .black.withAlphaComponent(0.6)
             }
         }
         
-        deleteButton.do {
-            $0.configuration?.title = I18N.detailDelete
-            $0.configuration?.cornerStyle = .capsule
-            $0.configuration?.attributedTitle?.font = .Pretendard(.semiBold, size: 16)
-            $0.configuration?.baseBackgroundColor = .black
-            $0.configuration?.baseForegroundColor = .white
-            $0.addTarget(self, action: #selector(deleteBtnTapped), for: .touchUpInside)
-        }
-        collectionView.do {
+        headerView.do {
             $0.backgroundColor = .white
             $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
             $0.layer.cornerRadius = 10
-            $0.bounces = false
-            $0.isScrollEnabled = false
         }
+        
+        collectionView.do {
+            $0.collectionViewLayout = layout()
+            $0.bounces = false
+            $0.backgroundColor = .white
+            $0.showsVerticalScrollIndicator = false
+            $0.contentInset = .init(top: -30, left: 0, bottom: 88, right: 0)
+        }
+        
+        deleteButton.do {
+            
+            var config = UIButton.Configuration.filled()
+            config.title = I18N.detailDelete
+            config.cornerStyle = .capsule
+            config.baseBackgroundColor = .black
+            config.baseForegroundColor = .white
+            config.attributedTitle?.font = .Pretendard(.semiBold, size: 16)
+            
+            $0.configuration = config
+            $0.addTarget(self, action: #selector(deleteBtnTapped), for: .touchUpInside)
+        }
+        
+        configureHeaderView()
     }
     
     private func setLayout() {
-        view.addSubviews(collectionView, deleteButton)
+        view.addSubviews(headerView, collectionView, deleteButton)
         
-        collectionView.snp.makeConstraints {
-            $0.height.equalTo(getDeviceHeight()*0.88)
-            $0.directionalHorizontalEdges.equalTo(safeArea)
-            $0.bottom.equalToSuperview()
+        headerView.snp.makeConstraints {
+            $0.top.equalTo(safeArea).inset(58)
+            $0.horizontalEdges.equalTo(safeArea)
+            $0.height.equalTo(74)
         }
+        
         deleteButton.snp.makeConstraints {
-            $0.directionalHorizontalEdges.equalToSuperview().inset(15)
+            $0.horizontalEdges.equalToSuperview().inset(15)
             $0.height.equalTo(50)
             $0.bottom.equalTo(safeArea).inset(10)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom)
+            $0.horizontalEdges.bottom.equalTo(safeArea)
         }
     }
     
     // MARK: - Data
     
     private func setupDataSource() {
-        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView, cellProvider: { collectionView, indexPath, item in
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MissionDetailCollectionViewCell.identifier, for: indexPath) as? MissionDetailCollectionViewCell else {return UICollectionViewCell()}
-            cell.configure(model: item as! MissionDetailResponseDTO)
-            return cell
+        
+        let cellRegistration = CellRegistration<MissionDetailCollectionViewCell, Item> {cell, _, item in
+            cell.configure(model: item)
+        }
+        
+        let footerRegistration = FooterRegistration<DetailFooterView>(elementKind: UICollectionView.elementKindSectionFooter) { footerView, _, _ in
+            footerView.footerClosure = {
+                let modalViewController = DetailCalendarViewController()
+                modalViewController.detailModel = self.detailModel
+                modalViewController.modalPresentationStyle = .overFullScreen
+                modalViewController.modalTransitionStyle = .crossDissolve
+                guard let id = self.userId else {return}
+                modalViewController.userId = id
+                modalViewController.movedateClosure = { [weak self] date in
+                    self?.dismiss(animated: true)
+                    self?.moveDateClosure?(date)
+                }
+                self.present(modalViewController, animated: false)
+            }
+        }
+        
+        dataSource = DataSource(collectionView: collectionView, cellProvider: { collectionView, indexPath, item in
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration,
+                                                                for: indexPath,
+                                                                item: item)
         })
+        
+        dataSource?.supplementaryViewProvider = { collectionView, _, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(using: footerRegistration,
+                                                                         for: indexPath)
+        }
     }
     
-    private func reloadData() {
-        var snapShot = NSDiffableDataSourceSnapshot<Section, Item>()
-        defer {
-            dataSource.apply(snapShot, animatingDifferences: false)
+    private func configureHeaderView() {
+        headerView.cancelClosure = {
+            self.view.alpha = 0
+            self.dismiss(animated: true) {
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.closeDetailMission)
+            }
         }
-        snapShot.appendSections([.mission])
-        snapShot.appendItems(detailModel, toSection: .mission)
         
-        dataSource.supplementaryViewProvider = { (collectionView, kind, indexPath) in
-            if kind == UICollectionView.elementKindSectionHeader {
-                guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: DetailHeaderReusableView.identifier, for: indexPath) as? DetailHeaderReusableView else {return UICollectionReusableView()}
-                header.cancelClosure = {
-
-                    self.view.alpha = 0
-                    self.dismiss(animated: true)
-                    AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.closeDetailMission)
-                }
-                header.editClosure = {
-                    AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.clickEditMission(section: "detail"))
-                    
-                    let updateMissionViewController = AddMissionViewController()
-                    guard let rootViewController = self.presentingViewController as? UINavigationController else { return }
-                    updateMissionViewController.setMissionId(self.userId ?? 0)
-                    updateMissionViewController.setViewType(.update)
-                    self.dismiss(animated: true) {
-                        rootViewController.pushViewController(updateMissionViewController, animated: true)
-                    }
-                }
-                return header
-            } else {
-                guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionFooter, withReuseIdentifier: DetailFooterReusableView.identifier, for: indexPath) as? DetailFooterReusableView else { return UICollectionReusableView() }
-                footer.footerClosure = {
-                    let modalViewController = DetailCalendarViewController()
-                    modalViewController.detailModel = self.detailModel
-                    modalViewController.modalPresentationStyle = .overFullScreen
-                    modalViewController.modalTransitionStyle = .crossDissolve
-                    guard let id = self.userId else {return}
-                    modalViewController.userId = id
-                    modalViewController.movedateClosure = { [weak self] date in
-                        self?.dismiss(animated: true)
-                        self?.moveDateClosure?(date)
-                    }
-                    self.present(modalViewController, animated: false)
-                }
-                return footer
+        headerView.editClosure = {
+            AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.clickEditMission(section: "detail"))
+            
+            let updateMissionViewController = AddMissionViewController()
+            guard let rootViewController = self.presentingViewController as? UINavigationController else { return }
+            updateMissionViewController.setMissionId(self.userId ?? 0)
+            updateMissionViewController.setViewType(.update)
+            self.dismiss(animated: true) {
+                rootViewController.pushViewController(updateMissionViewController, animated: true)
             }
         }
     }
     
+    private func setSnapShot() {
+        
+        var snapShot = SnapShot()
+        
+        if let detailModel = self.detailModel {
+            snapShot.appendSections([.main])
+            snapShot.appendItems([detailModel], toSection: .main)
+        }
+        
+        dataSource?.applySnapshotUsingReloadData(snapShot)
+    }
+    
     private func layout() -> UICollectionViewCompositionalLayout {
-        var config = UICollectionLayoutListConfiguration(appearance: .plain)
+        var config = UICollectionLayoutListConfiguration(appearance: .grouped)
+        config.backgroundColor = .white
         config.showsSeparators = false
-        config.headerMode = .supplementary
         config.footerMode = .supplementary
+        
         return UICollectionViewCompositionalLayout.list(using: config)
+        
     }
 }
 
@@ -169,53 +210,53 @@ extension MissionDetailViewController {
     
     @objc
     func deleteBtnTapped() {
-        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.clickDeleteMission(section: "detail", title: self.detailModel[0].title, situation: self.detailModel[0].situation, goal: self.detailModel[0].goal, action: [self.detailModel[0].actions[0].name]))
+        
+        guard let data = detailModel else { return }
+        AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.clickDeleteMission(section: "detail", title: data.title, situation: data.situation, goal: data.goal, action: [data.actions[0].name]))
+        
         let modalViewController = HomeDeleteViewController()
         modalViewController.modalPresentationStyle = .overFullScreen
         modalViewController.modalTransitionStyle = .crossDissolve
         modalViewController.deleteClosure = {
             guard let id = self.userId else { return }
-            
             self.requestDeleteMission(id: id)
         }
+        
         present(modalViewController, animated: false)
     }
 }
 
 extension MissionDetailViewController {
+    
     func requestDailyMissionAPI(id: Int) {
-        HomeAPI.shared.getDailyDetailMission(id: id) { [weak self] result in
-            switch result {
-            case let .success(data):
-                if let missionData = data as? MissionDetailResponseDTO {
-                    print("data: \(missionData)")
-                    self?.detailModel = [missionData]
-                    self?.reloadData()
-                } else {
-                    print("Failed to cast data to MissionDetailResponseDTO")
-                }
-            case .pathErr:
-                print("pathErr")
-            case .serverErr:
-                print("serverErr")
-            case .networkFail:
-                print("networkFail")
-            case .requestErr:
-                print("networkFail")
-            }
+        HomeAPI.shared.getDailyDetailMission(id: id) { [weak self] response in
+            guard let self else { return }
+            guard let response = response else { return }
+            guard let data = response.data else { return }
+            
+            self.detailModel = data
+            self.setSnapShot()
         }
     }
     
     private func requestDeleteMission(id: Int) {
         HomeAPI.shared.deleteMission(id: id) { [weak self] _ in
-            for index in 0..<(self?.detailModel.count ?? 0) {
-                if self?.detailModel[index].id == id {
-                    self?.deleteClosure?()
-                    self?.reloadData()
-                    AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.completeDeleteMission(section: "detail", title: (self?.detailModel[index].title)!, situation: (self?.detailModel[index].situation)!, goal: self?.detailModel[index].goal ?? "", action: [self?.detailModel[index].actions[index].name ?? ""]))
-                    self?.dismiss(animated: true)
+            guard let self else { return }
+            guard let data = self.detailModel else { return }
+            if data.id == id {
+                self.deleteClosure?()
+                self.setSnapShot()
+                
+                AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.completeDeleteMission(section: "detail",
+                                                                                                         title: data.title,
+                                                                                                         situation: data.situation,
+                                                                                                         goal: data.goal,
+                                                                                                         action: data.actions.map { $0.name }))
+                
+                self.dismiss(animated: true) {
+                    
                     AmplitudeAnalyticsService.shared.send(event: AnalyticsEvent.Detail.closeDetailMission)
-                } else {}
+                }
             }
         }
     }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/MissionDetailViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Home/ViewControllers/MissionDetailViewController.swift
@@ -10,11 +10,6 @@ import UIKit
 import Then
 import SnapKit
 
-import UIKit
-
-import Then
-import SnapKit
-
 final class MissionDetailViewController: UIViewController {
     
     // MARK: - Properties


### PR DESCRIPTION
## 🫧 작업한 내용
 - 미션 리스트 디테일 UI 로직 변경했습니다. 
- 스크롤 영역을 수정했습니다.

## 🔫 PR Point
cancel버튼과 edit 버튼을 collectionview의 헤더로 구현했더니 se에서 같이 스크롤이 되는 문제가 발생했습니다. 
리팩토링하면서 cancel버튼과 edit 버튼은 따로 headerTopview로 구현하여 스크롤 영역을 수정했습니다. 
또한,  레이아웃의 속성을 `UICollectionLayoutListConfiguration(appearance: .plain)`으로 주었더니 footer는 스크롤이 되지 않아서 속성을 `UICollectionLayoutListConfiguration(appearance: .grouped)` 으로 변경했습니다.

## 📸 스크린샷 

### 기존 화면

https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/91e9f33b-5478-4e5a-81aa-6c974becb826

### 수정된 화면

https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/225d60b8-48a6-4885-a18b-68c2f531c844


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #197
