### PR TITLE
[Fix] #253 - 푸시 알림 요청 오류 수정

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
+++ b/iOS-NOTTODO/iOS-NOTTODO.xcodeproj/project.pbxproj
@@ -154,7 +154,6 @@
 		6C44127529A35A1000313C3F /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 6C44127429A35A1000313C3F /* KakaoSDKCommon */; };
 		6C44127729A35A1000313C3F /* KakaoSDKNavi in Frameworks */ = {isa = PBXBuildFile; productRef = 6C44127629A35A1000313C3F /* KakaoSDKNavi */; };
 		6C44127929A35A1000313C3F /* KakaoSDKShare in Frameworks */ = {isa = PBXBuildFile; productRef = 6C44127829A35A1000313C3F /* KakaoSDKShare */; };
-		6C44127B29A35A1000313C3F /* KakaoSDKStory in Frameworks */ = {isa = PBXBuildFile; productRef = 6C44127A29A35A1000313C3F /* KakaoSDKStory */; };
 		6C44127D29A35A1000313C3F /* KakaoSDKTalk in Frameworks */ = {isa = PBXBuildFile; productRef = 6C44127C29A35A1000313C3F /* KakaoSDKTalk */; };
 		6C44127F29A35A1000313C3F /* KakaoSDKTemplate in Frameworks */ = {isa = PBXBuildFile; productRef = 6C44127E29A35A1000313C3F /* KakaoSDKTemplate */; };
 		6C44128129A35A1000313C3F /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 6C44128029A35A1000313C3F /* KakaoSDKUser */; };
@@ -187,6 +186,19 @@
 		6CF4707429A73D4C008D145C /* RecommendCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF4707329A73D4C008D145C /* RecommendCollectionViewCell.swift */; };
 		6CF4707A29A7AAFF008D145C /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF4707929A7AAFF008D145C /* PaddingLabel.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		3B1E84A92BAC897E002F9808 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		09022D4529C44BC300DE6E49 /* MissionCalendarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionCalendarCell.swift; sourceTree = "<group>"; };
@@ -291,6 +303,8 @@
 		3B14A13E29A6FCB300F92897 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		3B14A14029A6FDA900F92897 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		3B14A14229A6FEE400F92897 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
+		3B1E84932BAC897C002F9808 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		3B1E84952BAC897C002F9808 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		3B37AE2829C8821600AB7587 /* GoalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCollectionViewCell.swift; sourceTree = "<group>"; };
 		3B37AE2A29C8904800AB7587 /* RecommendKeywordCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendKeywordCollectionViewCell.swift; sourceTree = "<group>"; };
 		3B3EF2F72AF35C90001F79BC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -364,7 +378,6 @@
 				3B146DA1299D0A7A00B17B62 /* SnapKit in Frameworks */,
 				6CA2082C2A19122A001C4247 /* Kingfisher in Frameworks */,
 				6C44127929A35A1000313C3F /* KakaoSDKShare in Frameworks */,
-				6C44127B29A35A1000313C3F /* KakaoSDKStory in Frameworks */,
 				6C9628A72A22208F003ADE25 /* Lottie in Frameworks */,
 				6C44127F29A35A1000313C3F /* KakaoSDKTemplate in Frameworks */,
 				6C44127129A35A1000313C3F /* KakaoSDK in Frameworks */,
@@ -679,6 +692,8 @@
 		155E45642B5FF089008628E7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				3B1E84932BAC897C002F9808 /* WidgetKit.framework */,
+				3B1E84952BAC897C002F9808 /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1247,6 +1262,7 @@
 				3B027A70299C31B500BEB65C /* Sources */,
 				3B027A71299C31B500BEB65C /* Frameworks */,
 				3B027A72299C31B500BEB65C /* Resources */,
+				3B1E84A92BAC897E002F9808 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
@@ -1262,7 +1278,6 @@
 				6C44127429A35A1000313C3F /* KakaoSDKCommon */,
 				6C44127629A35A1000313C3F /* KakaoSDKNavi */,
 				6C44127829A35A1000313C3F /* KakaoSDKShare */,
-				6C44127A29A35A1000313C3F /* KakaoSDKStory */,
 				6C44127C29A35A1000313C3F /* KakaoSDKTalk */,
 				6C44127E29A35A1000313C3F /* KakaoSDKTemplate */,
 				6C44128029A35A1000313C3F /* KakaoSDKUser */,
@@ -1284,7 +1299,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1420;
+				LastSwiftUpdateCheck = 1530;
 				LastUpgradeCheck = 1420;
 				TargetAttributes = {
 					3B027A73299C31B500BEB65C = {
@@ -1884,11 +1899,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6C44126F29A35A1000313C3F /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
 			productName = KakaoSDKShare;
-		};
-		6C44127A29A35A1000313C3F /* KakaoSDKStory */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6C44126F29A35A1000313C3F /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
-			productName = KakaoSDKStory;
 		};
 		6C44127C29A35A1000313C3F /* KakaoSDKTalk */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/Auth/AuthViewController.swift
@@ -280,9 +280,9 @@ extension AuthViewController {
     }
     
     func showNotiDialogView() {
-        DispatchQueue.main.async {
-            self.coordinator?.showNotificationViewController { [weak self] in
-                guard let self else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.coordinator?.showNotificationViewController {
                 self.requestNotification()
             }
         }


### PR DESCRIPTION
## 🫧 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 애플 로그인 시 푸시 알림 요청 함수가 호출되지 않는 오류를 수정했습니다.

## 🔫 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- 카카오 로그인에서는 buttonHandler에 completion이 제대로 할당되는데 애플 로그인 시에는 할당이 제대로 되지 않았던 것 같습니다! `showNotificationViewController`에서만 self를 확인하면 외부 클로저에서 self가 nil인 경우 호출이 되지 않아 외부 클로저에서 self를 확인하는 로직으로 수정했습니다.


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #253 
