### PR TITLE
[Fix] #256 - Mission error 로직 처리

### DIFF
--- a/iOS-NOTTODO/iOS-NOTTODO/Network/Base/APIError.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Network/Base/APIError.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum APIError: Error, Equatable {
+enum APIError: Error, Equatable {
     case network(statusCode: Int, response: ErrorResponse)
     case unknown
     case tokenReissuanceFailed

--- a/iOS-NOTTODO/iOS-NOTTODO/Network/Base/ErrorReponse.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Network/Base/ErrorReponse.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-public struct ErrorResponse: Decodable, Equatable {
-    public let statusCode: String
-    public let responseMessage: String
+struct ErrorResponse: Decodable, Equatable {
+    let status: Int
+    let success: Bool
+    let message: String
 }

--- a/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
+++ b/iOS-NOTTODO/iOS-NOTTODO/Presentation/AddMission/ViewControllers/AddMissionViewController.swift
@@ -280,49 +280,47 @@ extension AddMissionViewController {
     private func requestPostAddMission(title: String, situation: String,
                                        actions: [String]?, goal: String?, dates: [String]?) {
         let request = AddMissionRequest(title: title, situation: situation, actions: actions, goal: goal, dates: dates ?? [""])
-        MissionService.shared.postAddMission(request: request) { response in
-            guard let response = response else { return }
-            switch response.status {
-            case 200..<300:
-                AmplitudeAnalyticsService.shared.send(
-                    event: AnalyticsEvent.CreateMission.completeCreateMission(
-                        date: dates ?? [],
-                        goal: goal ?? "",
-                        title: title,
-                        situation: situation,
-                        action: actions ?? []
-                    )
-                )
-                self.coordinator?.dismiss()
-            default:
-                let toastMessage = self.htmlToString(response.message ?? "")?.string ?? ""
+        MissionService.shared.postAddMission(request: request) { err in
+            if let err = err {
+                let toastMessage = self.htmlToString(err.message)?.string ?? ""
                 self.checkToastMessage(toastMessage)
                 self.showToast(message: toastMessage, controller: self)
+                return
             }
+            
+            AmplitudeAnalyticsService.shared.send(
+                event: AnalyticsEvent.CreateMission.completeCreateMission(
+                    date: dates ?? [],
+                    goal: goal ?? "",
+                    title: title,
+                    situation: situation,
+                    action: actions ?? []
+                )
+            )
+            self.coordinator?.dismiss()
+            
         }
     }
     
     private func requestPutUpdateMission(id: Int, title: String, situation: String, actions: [String]?, goal: String?) {
         let request = UpdateMissionRequest(id: id, title: title, situation: situation, actions: actions, goal: goal)
-        MissionService.shared.putUpdateMission(request: request) { response in
-            guard let response = response else { return }
-            print(response.status)
-            switch response.status {
-            case 200..<300:
-                AmplitudeAnalyticsService.shared.send(
-                    event: AnalyticsEvent.UpdateMission.completeUpdateMission(
-                        date: self.dateList,
-                        goal: self.nottodoInfoList[4],
-                        title: self.nottodoInfoList[1],
-                        situation: self.nottodoInfoList[2],
-                        action: self.nottodoInfoList[3])
-                )
-                self.coordinator?.dismiss()
-            default:
-                let toastMessage = self.htmlToString(response.message ?? "")?.string ?? ""
+        MissionService.shared.putUpdateMission(request: request) { err in
+            if let err = err {
+                let toastMessage = self.htmlToString(err.message)?.string ?? ""
                 self.checkToastMessage(toastMessage)
                 self.showToast(message: toastMessage, controller: self)
+                return
             }
+            
+            AmplitudeAnalyticsService.shared.send(
+                event: AnalyticsEvent.UpdateMission.completeUpdateMission(
+                    date: self.dateList,
+                    goal: self.nottodoInfoList[4],
+                    title: self.nottodoInfoList[1],
+                    situation: self.nottodoInfoList[2],
+                    action: self.nottodoInfoList[3])
+            )
+            self.coordinator?.dismiss()
         }
     }
     


### PR DESCRIPTION
## 🫧 작업한 내용
- mission관련 api 콜 error 로직 처리

## 🔫 PR Point
- 문제의 원인
   -  failure 케이스에서 completion(nil)을 호출하여, 에러가 발생했을 때도 응답 데이터가 nil로 전달되어 토스트 메시지를 표시하지 못함. 
- 문제 해결 과정
   - 코드를 살펴보니 성공적인 응답을 받았을 때 단순히 상태 코드에 대한 분기 처리만을 수행함
   - completion으로 성공 응답에 대한 reponse를 전달하는 것이 아닌 error가 내려왔을때 reponse를 전달
- 문제 해결
   - 실패인 경우 completion 클로저를 통해 에러를 받아 토스트 메시지를 표시하고, 성공적인 응답이라면 그에 따른 로직을 처리할 수 있도록 수정
   
[error 처리 ❌]
 ```
case .success(let response):
                do {
                    let response = try response.map(UpdateMissionStatus?.self)
                    completion(response)
                } catch let err {
                    print(err.localizedDescription, 500)
                }
            case .failure(let err):
                print(err.localizedDescription)
                completion(nil)
            }
    }
```
[error 처리 ⭕️]
```
case .failure(let err):
                if let response = err.response {
                    do {
                        let errorResponse = try response.map(ErrorResponse.self)
                        print("💎 Server Error 💎: \(errorResponse.message)")
                        completion(errorResponse)
                    } catch {
                        print("💎 Mapping Error 💎: \(error.localizedDescription)")
                        completion(nil)
                    }
                } else {
                    print("💎 Network Error 💎: \(err.localizedDescription)")
                    completion(nil)
                }
            }
```

## 📸 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

 |   다른 날짜 추가   |  낫투두 수정     |   낫투두 생성   |
| :----------: | :----------: | :----------: |
|<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/68a732a8-bd0a-4179-8911-5f6af7d76854" width ="250">|<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/e9919f33-4bae-4e2c-aef9-304ed44a246f" width ="250">|<img src = "https://github.com/DO-NOTTO-DO/iOS-NOTTODO/assets/107853954/8e8e9225-4705-4e57-8a05-7202922e6a0f" width ="250">|

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #256
